### PR TITLE
エラー画面を修正、DBエラーの際にエラー画面に遷移するように修正

### DIFF
--- a/Diary-Sample/Controllers/CreateController.cs
+++ b/Diary-Sample/Controllers/CreateController.cs
@@ -38,7 +38,6 @@ namespace Diary_Sample.Controllers
 
             if (!ModelState.IsValid)
             {
-                // var errormsgs = ModelState.SelectMany(x => x.Value.Errors.Select(z => z.ErrorMessage));
                 return View("Index", model);
             }
             if (_service.Create(model))

--- a/Diary-Sample/Diary-Sample.csproj
+++ b/Diary-Sample/Diary-Sample.csproj
@@ -7,11 +7,11 @@
     <CodeAnalysisRuleSet>Analyzers.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8"/>
-    <PackageReference Include="MySql.Data.EntityFrameworkCore" Version="8.0.19"/>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0"/>
-    <PackageReference Include="AspNetCore.RouteAnalyzer" Version="0.5.3"/>
-    <AdditionalFiles Include="stylecop.json" Link="stylecop.json"/>
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
+    <PackageReference Include="MySql.Data.EntityFrameworkCore" Version="8.0.19" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
+    <PackageReference Include="AspNetCore.RouteAnalyzer" Version="0.5.3" />
+    <AdditionalFiles Include="stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 </Project>

--- a/Diary-Sample/Repositories/DiaryRepository.cs
+++ b/Diary-Sample/Repositories/DiaryRepository.cs
@@ -32,41 +32,52 @@ namespace Diary_Sample.Repositories
             catch (MySqlException e)
             {
                 _logger.LogError(e.Message);
+                _logger.LogError(e.StackTrace);
+                throw;
             }
-            return false;
         }
         public List<Diary> read(int page, int count)
         {
-            List<Diary> result = new List<Diary>();
             try
             {
-                result = _context.diary.OrderByDescending(x => x.post_date).Skip((page - 1) * count).Take(count).ToList();
-                result.ForEach(x =>
-               {
-                   _logger.LogInformation($"{x.id} {x.title} {x.content} {x.post_date} {x.update_date}");
-               });
+                return _context.diary
+                    .OrderByDescending(x => x.post_date)
+                    .Skip((page - 1) * count)
+                    .Take(count)
+                    .ToList()
+                    .Select(x =>
+                    {
+                        outputLog(x);
+                        return x;
+                    })
+                    .ToList();
             }
             catch (MySqlException e)
             {
                 _logger.LogError(e.Message);
+                _logger.LogError(e.StackTrace);
+                throw;
             }
-
-            return result;
         }
 
         public int readCount()
         {
-            int count = 0;
             try
             {
-                count = _context.diary.Count();
+                return _context.diary.Count();
             }
             catch (MySqlException e)
             {
                 _logger.LogError(e.Message);
+                _logger.LogError(e.StackTrace);
+                throw;
             }
+        }
 
-            return count;
+        private void outputLog(Diary x)
+        {
+            // DBから取得した内容をログに出力
+            _logger.LogInformation($"{x.id} {x.title} {x.content} {x.post_date} {x.update_date}");
         }
     }
 }

--- a/Diary-Sample/Startup.cs
+++ b/Diary-Sample/Startup.cs
@@ -46,7 +46,7 @@ namespace Diary_Sample
             }
             else
             {
-                app.UseExceptionHandler("/Diary/Error");
+                app.UseExceptionHandler("/Menu/Error");
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }

--- a/Diary-Sample/Views/Shared/Error.cshtml
+++ b/Diary-Sample/Views/Shared/Error.cshtml
@@ -1,25 +1,18 @@
-﻿@model ErrorViewModel
+@model ErrorViewModel
 @{
     ViewData["Title"] = "Error";
 }
 
-<h1 class="text-danger">Error.</h1>
-<h2 class="text-danger">An error occurred while processing your request.</h2>
+    <h3 class="text-info">
+        <br />
+        <br />
+        <br />
+        <br />
+        😫申し訳ございません。システムエラーが発生しました。<br />
+        しばらく時間をおいてから再度お試しください😞<br />
+        <br />
+        <br />
+        <br />
+        <br />
+    </h3>
 
-@if (Model.ShowRequestId)
-{
-    <p>
-        <strong>Request ID:</strong> <code>@Model.RequestId</code>
-    </p>
-}
-
-<h3>Development Mode</h3>
-<p>
-    Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
-</p>
-<p>
-    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
-    It can result in displaying sensitive information from exceptions to end users.
-    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
-    and restarting the app.
-</p>

--- a/Diary-Sample/Views/Shared/_Layout.cshtml
+++ b/Diary-Sample/Views/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-﻿﻿<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">


### PR DESCRIPTION
# 変更内容

#### エラー画面の表示を修正しました。
#### 開発環境と開発環境以外でエラー画面表示を切り替えるように修正しました。

---

##### launchSettings.jsonの`ASPNETCORE_ENVIRONMENT`の値が

- ##### `Development`の場合
    - 以下の.NET標準の開発用エラー画面を表示する（エラーメッセージやスタックトレースが表示される）
      <img src="https://user-images.githubusercontent.com/15532048/85947133-e316d480-b983-11ea-8a7c-2be3a73bcd99.png" width="700px">

- ##### `Staging`・`Staging_2`・`Production`の場合
    - 以下の画面（error.cshtml）を表示する
      <img src="https://user-images.githubusercontent.com/15532048/85947399-62f16e80-b985-11ea-8312-cba041557318.png" width="700px">
    - 開発環境以外では画面にエラー情報は表示されないので、エラーの情報はログに出力するようにする

##### エラー画面は例外を上位にそのままスローすれば表示される。一度キャッチし、エラーログを出力した後、そのままスローする。

```
try
{
   ...
}
catch (XXXException e)
{
    _logger.LogError(e.Message);
    _logger.LogError(e.StackTrace);
    throw;
}
```