### PR TITLE
DB接続文字列を設定ファイルに移動、環境別設定ファイルを追加

### DIFF
--- a/Diary-Sample/Entities/DiarySampleContext.cs
+++ b/Diary-Sample/Entities/DiarySampleContext.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Diary_Sample.Entities
@@ -11,6 +12,13 @@ namespace Diary_Sample.Entities
     public partial class DiarySampleContext : DbContext
     {
         public DbSet<Diary>? diary { get; set; }
+        private readonly IConfiguration _config;
+
+        public DiarySampleContext(IConfiguration config)
+        {
+            _config = config;
+        }
+
         public static readonly ILoggerFactory MySQLLoggerFactory = LoggerFactory.Create(builder => { builder.AddConsole(); });
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -20,10 +28,9 @@ namespace Diary_Sample.Entities
             }
             if (!optionsBuilder.IsConfigured)
             {
-                // TODO DB設定は後で設定ファイルに持つようにする・環境ごとに設定を変更できるようにする
                 optionsBuilder
                 .UseLoggerFactory(MySQLLoggerFactory)
-                .UseMySQL(@"server=localhost;port=3306;database=DiarySample;userid=user;pwd=password;sslmode=Required;");
+                .UseMySQL(_config.GetConnectionString("DbConnectionString"));
             }
         }
     }

--- a/Diary-Sample/Properties/launchSettings.json
+++ b/Diary-Sample/Properties/launchSettings.json
@@ -26,6 +26,9 @@
     "Docker": {
       "commandName": "Docker",
       "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Production"
+      },
       "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}",
       "publishAllPorts": true,
       "useSSL": true

--- a/Diary-Sample/appsettings.Development.json
+++ b/Diary-Sample/appsettings.Development.json
@@ -5,5 +5,8 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "ConnectionStrings": {
+    "DbConnectionString": "server=localhost;port=3306;database=DiarySample;userid=user;pwd=password;sslmode=Required;"
   }
 }

--- a/Diary-Sample/appsettings.Production.json
+++ b/Diary-Sample/appsettings.Production.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Debug",
+      "Default": "Information",
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }

--- a/Diary-Sample/appsettings.Production.json
+++ b/Diary-Sample/appsettings.Production.json
@@ -5,5 +5,8 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "ConnectionStrings": {
+    "DbConnectionString": "server=db;port=3306;database=DiarySample;userid=user;pwd=password;sslmode=Required;"
   }
 }

--- a/Diary-Sample/appsettings.json
+++ b/Diary-Sample/appsettings.json
@@ -6,8 +6,5 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*",
-  "ConnectionStrings": {
-    "DbConnectionString": "server=localhost;port=3306;database=DiarySample;userid=user;pwd=password;sslmode=Required;"
-  }
+  "AllowedHosts": "*"
 }

--- a/Diary-Sample/appsettings.json
+++ b/Diary-Sample/appsettings.json
@@ -6,5 +6,8 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DbConnectionString": "server=localhost;port=3306;database=DiarySample;userid=user;pwd=password;sslmode=Required;"
+  }
 }


### PR DESCRIPTION
## 変更内容
DBの接続文字列を設定ファイルに移動しました。
設定ファイルは環境ごとに設定できるようにしました。

- 共通設定
  appsettings.json
- 開発環境用（ローカル環境の場合）
  appsettings.Development.json
- 本番環境用（Dockerコンテナの場合）
  appsettings.Production.json

上記ファイルの設定は、以下の順番で読み込まれます。
同じ設定を複数ファイルに記述したら、環境ごとのjsonファイルの内容で上書きされます。
```
appsettings.json -> appsettings.{env}.json
```

### 環境変数の設定
以下でそれぞれ設定する。

- Visual Studio 2019
  `メニュー > デバッグ > DiarySampleのデバッグプロパティ`を開き、`ASPNETCORE_ENVIRONMENT`を設定する
  ![スクリーンショット 2020-08-15 104857](https://user-images.githubusercontent.com/15532048/90303034-7335bc80-dee5-11ea-95f7-ae0b2dd03a6a.png)

- Visual Studio Code
  `Diary-Sample/Properties/launchSettings.json`を開き、`ASPNETCORE_ENVIRONMENT`を設定する
  ![スクリーンショット 2020-08-15 110829](https://user-images.githubusercontent.com/15532048/90303300-d1639f00-dee7-11ea-98cd-74eeb389de1c.png)





