### PR TITLE
MySQLの文字コード指定を「utf8mb4」に修正

### DIFF
--- a/Diary-Sample/docker-compose.yml
+++ b/Diary-Sample/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   db:
     image: mysql
     command: --default-authentication-plugin=mysql_native_password
-    command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: password


### PR DESCRIPTION
# 変更内容
以下の事象に対応するため、MySQLの文字コードを`utf8`から`utf8mb4`に変更
[\[Issue\] 絵文字が登録できない](https://github.com/1-system-group/Diary-Sample/issues/18)

MySQLの文字コード指定`utf8`では3バイト文字までしかサポートしておらず、絵文字のような4バイト文字が扱えない。
これに対応するため、4バイト文字含むUTF-8が扱える`utf8mb4`の指定に変更する。

また、それに伴いcollation（照合順序）を`utf8_unicode_ci`から`utf8mb4_bin`に修正。

詳細は[Wiki](https://github.com/1-system-group/Diary-Sample/wiki/MySQL-Tips)を参照
