### PR TITLE
DiaryRepositoryTest.csのテストメソッド追加と、CommonUtilTest.csの新規作成

### DIFF
--- a/Diary-Sample-Test/Common/CommonUtilTest.cs
+++ b/Diary-Sample-Test/Common/CommonUtilTest.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Diary_Sample.Common;
+using Xunit;
+
+namespace Diary_Sample_Test.Common
+{
+    public class CommonUtilTest
+    {
+        public CommonUtilTest()
+        {
+        }
+
+        // 正常系：最小値、最大値
+        [Fact]
+        public void ConvAcceptIdTest001()
+        {
+            int ret1 = CommonUtil.ConvAcceptId("1");
+            Assert.Equal(1, ret1);
+
+            int ret2 = CommonUtil.ConvAcceptId("16777215");
+            Assert.Equal(16777215, ret2);
+        }
+
+        // 異常系：null
+        [Fact]
+        public void ConvAcceptIdTest002()
+        {
+            int ret = CommonUtil.ConvAcceptId(null);
+            Assert.Equal(-1, ret);
+        }
+
+        // 異常系：半角数字以外
+        [Fact]
+        public void ConvAcceptIdTest003()
+        {
+            int ret = CommonUtil.ConvAcceptId("１２３４５");
+            Assert.Equal(-1, ret);
+        }
+
+        // 正常系：範囲外
+        [Fact]
+        public void ConvAcceptIdTest004()
+        {
+            int ret1 = CommonUtil.ConvAcceptId("0");
+            Assert.Equal(-1, ret1);
+
+            int ret2 = CommonUtil.ConvAcceptId("16777216");
+            Assert.Equal(-1, ret2);
+        }
+    }
+}

--- a/Diary-Sample-Test/Common/CommonUtilTest.cs
+++ b/Diary-Sample-Test/Common/CommonUtilTest.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Diary_Sample.Common;
 using Xunit;
 

--- a/Diary-Sample-Test/Repositories/DiaryRepositoryTest.cs
+++ b/Diary-Sample-Test/Repositories/DiaryRepositoryTest.cs
@@ -39,6 +39,7 @@ namespace Diary_Sample_Test.Repositories
                                                    where paramInfos.Length == 1 && paramInfos[0].ParameterType == typeof(string)
                                                    select consInfo).Single();
             mockException = internalConstructor.Invoke(new[] { "DBエラー" }) as Exception;
+
             repository = new DiaryRepository(mockLogger.Object, mockContext.Object);
         }
 

--- a/Diary-Sample-Test/Repositories/DiaryRepositoryTest.cs
+++ b/Diary-Sample-Test/Repositories/DiaryRepositoryTest.cs
@@ -268,6 +268,268 @@ namespace Diary_Sample_Test.Repositories
                 Assert.Equal("DBエラー", e.Message);
             }
         }
+
+        // 正常系：データありのキー値を指定
+        [Fact]
+        public void ReadTest001()
+        {
+            IQueryable<Diary> data = new List<Diary>
+            {
+                new Diary(1, "たいとる１（てすと）", "ほんぶん１（てすと）"),
+                new Diary(2, "たいとる２（てすと）", "ほんぶん２（てすと）"),
+                new Diary(3, "たいとる３（てすと）", "ほんぶん３（てすと）"),
+                new Diary(4, "たいとる４（てすと）", "ほんぶん４（てすと）"),
+                new Diary(5, "たいとる５（てすと）", "ほんぶん５（てすと）"),
+                new Diary(6, "たいとる６（てすと）", "ほんぶん６（てすと）"),
+                new Diary(7, "たいとる７（てすと）", "ほんぶん７（てすと）"),
+            }.AsQueryable();
+            SetIQueryable(data);
+            mockContext.Setup(x => x.diary).Returns(mockSet.Object);
+
+            var resultList = repository.Read(3);
+
+            Assert.Single(resultList);
+            var result = resultList[0];
+            Assert.Equal(3, result.id);
+            Assert.Equal("たいとる３（てすと）", result.title);
+            Assert.Equal("ほんぶん３（てすと）", result.content);
+        }
+
+        // 正常系：データなしのキー値を指定
+        [Fact]
+        public void ReadTest002()
+        {
+            IQueryable<Diary> data = new List<Diary>
+            {
+                new Diary(1, "たいとる１（てすと）", "ほんぶん１（てすと）"),
+                new Diary(2, "たいとる２（てすと）", "ほんぶん２（てすと）"),
+                new Diary(3, "たいとる３（てすと）", "ほんぶん３（てすと）"),
+                new Diary(4, "たいとる４（てすと）", "ほんぶん４（てすと）"),
+                new Diary(5, "たいとる５（てすと）", "ほんぶん５（てすと）"),
+                new Diary(6, "たいとる６（てすと）", "ほんぶん６（てすと）"),
+                new Diary(7, "たいとる７（てすと）", "ほんぶん７（てすと）"),
+            }.AsQueryable();
+            SetIQueryable(data);
+            mockContext.Setup(x => x.diary).Returns(mockSet.Object);
+
+            var resultList = repository.Read(8);
+
+            Assert.Empty(resultList);
+        }
+
+        // 異常系：MySqlException
+        [Fact]
+        public void ReadTest003()
+        {
+            Diary diary = new Diary(1, "たいとる１（てすと）", "ほんぶん１（てすと）");
+            mockContext.Setup(x => x.Add(diary));
+            mockContext.Setup(x => x.SaveChanges()).Throws(mockException);
+
+            var exception = Assert.Throws<MySqlException>(() =>
+            {
+                bool result = repository.create(diary);
+            });
+            Assert.Equal("DBエラー", exception.Message);
+            mockLogger.Verify(
+                x => x.Log(
+                        LogLevel.Error,
+                        It.IsAny<EventId>(),
+                        It.IsAny<It.IsAnyType>(),
+                        It.IsAny<Exception>(),
+                        (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+                Times.Exactly(2));
+        }
+
+        // 正常系：レコード更新
+        [Fact]
+        public void UpdateTest001()
+        {
+            IQueryable<Diary> data = new List<Diary>
+            {
+                new Diary(1, "たいとる１（てすと）", "ほんぶん１（てすと）"),
+                new Diary(2, "たいとる２（てすと）", "ほんぶん２（てすと）"),
+                new Diary(3, "たいとる３（てすと）", "ほんぶん３（てすと）"),
+                new Diary(4, "たいとる４（てすと）", "ほんぶん４（てすと）"),
+                new Diary(5, "たいとる５（てすと）", "ほんぶん５（てすと）"),
+                new Diary(6, "たいとる６（てすと）", "ほんぶん６（てすと）"),
+                new Diary(7, "たいとる７（てすと）", "ほんぶん７（てすと）"),
+            }.AsQueryable();
+            SetIQueryable(data);
+            mockContext.Setup(x => x.diary).Returns(mockSet.Object);
+            Diary diary = new Diary(2, "タイトル２（てすと）を更新", "ほんぶん２（てすと）を更新");
+            mockContext.Setup(x => x.Add(diary));
+            mockContext.Setup(x => x.SaveChanges()).Returns(1);
+
+            bool result = repository.Update(diary);
+
+            Assert.True(result);
+        }
+
+        // 準正常系：存在しないレコードを更新
+        [Fact]
+        public void UpdateTest002()
+        {
+            IQueryable<Diary> data = new List<Diary>
+            {
+                new Diary(1, "たいとる１（てすと）", "ほんぶん１（てすと）"),
+                new Diary(2, "たいとる２（てすと）", "ほんぶん２（てすと）"),
+                new Diary(3, "たいとる３（てすと）", "ほんぶん３（てすと）"),
+                new Diary(4, "たいとる４（てすと）", "ほんぶん４（てすと）"),
+                new Diary(5, "たいとる５（てすと）", "ほんぶん５（てすと）"),
+                new Diary(6, "たいとる６（てすと）", "ほんぶん６（てすと）"),
+                new Diary(7, "たいとる７（てすと）", "ほんぶん７（てすと）"),
+            }.AsQueryable();
+            SetIQueryable(data);
+            mockContext.Setup(x => x.diary).Returns(mockSet.Object);
+            Diary diary = new Diary(8, "タイトル８（てすと）を更新", "ほんぶん８（てすと）を更新");
+            mockContext.Setup(x => x.Add(diary));
+            mockContext.Setup(x => x.SaveChanges()).Returns(1);
+
+            bool result = repository.Update(diary);
+
+            Assert.False(result);
+            mockLogger.Verify(
+                        x => x.Log(
+                  LogLevel.Error,
+                  It.IsAny<EventId>(),
+                  It.IsAny<It.IsAnyType>(),
+                  It.IsAny<Exception>(),
+                  (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+                        Times.Exactly(2));
+        }
+
+        // 異常系：MySqlException
+        [Fact]
+        public void UpdateTest003()
+        {
+            IQueryable<Diary> data = new List<Diary>
+            {
+                new Diary(1, "たいとる１（てすと）", "ほんぶん１（てすと）"),
+                new Diary(2, "たいとる２（てすと）", "ほんぶん２（てすと）"),
+                new Diary(3, "たいとる３（てすと）", "ほんぶん３（てすと）"),
+                new Diary(4, "たいとる４（てすと）", "ほんぶん４（てすと）"),
+                new Diary(5, "たいとる５（てすと）", "ほんぶん５（てすと）"),
+                new Diary(6, "たいとる６（てすと）", "ほんぶん６（てすと）"),
+                new Diary(7, "たいとる７（てすと）", "ほんぶん７（てすと）"),
+            }.AsQueryable();
+            SetIQueryable(data);
+            mockContext.Setup(x => x.diary).Returns(mockSet.Object);
+            Diary diary = new Diary(1, "タイトル１（てすと）を更新", "ほんぶん１（てすと）を更新");
+            mockContext.Setup(x => x.Add(diary));
+            mockContext.Setup(x => x.SaveChanges()).Returns(1);
+            mockContext.Setup(x => x.SaveChanges()).Throws(mockException);
+
+            var exception = Assert.Throws<MySqlException>(() =>
+            {
+                bool result = repository.Update(diary);
+            });
+            Assert.Equal("DBエラー", exception.Message);
+
+            mockLogger.Verify(
+                x => x.Log(
+                        LogLevel.Error,
+                        It.IsAny<EventId>(),
+                        It.IsAny<It.IsAnyType>(),
+                        It.IsAny<Exception>(),
+                        (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+                Times.Exactly(2));
+        }
+
+        // 正常系：レコード削除
+        [Fact]
+        public void DeleteTest001()
+        {
+            IQueryable<Diary> data = new List<Diary>
+            {
+                new Diary(1, "たいとる１（てすと）", "ほんぶん１（てすと）"),
+                new Diary(2, "たいとる２（てすと）", "ほんぶん２（てすと）"),
+                new Diary(3, "たいとる３（てすと）", "ほんぶん３（てすと）"),
+                new Diary(4, "たいとる４（てすと）", "ほんぶん４（てすと）"),
+                new Diary(5, "たいとる５（てすと）", "ほんぶん５（てすと）"),
+                new Diary(6, "たいとる６（てすと）", "ほんぶん６（てすと）"),
+                new Diary(7, "たいとる７（てすと）", "ほんぶん７（てすと）"),
+            }.AsQueryable();
+            SetIQueryable(data);
+            mockContext.Setup(x => x.diary).Returns(mockSet.Object);
+            Diary diary = new Diary(2, "タイトル２（てすと）を更新", "ほんぶん２（てすと）を更新");
+            mockContext.Setup(x => x.Add(diary));
+            mockContext.Setup(x => x.SaveChanges()).Returns(1);
+
+            bool result = repository.Delete(2);
+
+            Assert.True(result);
+        }
+
+        // 準正常系：存在しないレコードを削除
+        [Fact]
+        public void DeleteTest002()
+        {
+            IQueryable<Diary> data = new List<Diary>
+            {
+                new Diary(1, "たいとる１（てすと）", "ほんぶん１（てすと）"),
+                new Diary(2, "たいとる２（てすと）", "ほんぶん２（てすと）"),
+                new Diary(3, "たいとる３（てすと）", "ほんぶん３（てすと）"),
+                new Diary(4, "たいとる４（てすと）", "ほんぶん４（てすと）"),
+                new Diary(5, "たいとる５（てすと）", "ほんぶん５（てすと）"),
+                new Diary(6, "たいとる６（てすと）", "ほんぶん６（てすと）"),
+                new Diary(7, "たいとる７（てすと）", "ほんぶん７（てすと）"),
+            }.AsQueryable();
+            SetIQueryable(data);
+            mockContext.Setup(x => x.diary).Returns(mockSet.Object);
+            Diary diary = new Diary(8, "タイトル８（てすと）を更新", "ほんぶん８（てすと）を更新");
+            mockContext.Setup(x => x.Add(diary));
+            mockContext.Setup(x => x.SaveChanges()).Returns(1);
+
+            bool result = repository.Delete(8);
+
+            Assert.False(result);
+            mockLogger.Verify(
+                        x => x.Log(
+                  LogLevel.Error,
+                  It.IsAny<EventId>(),
+                  It.IsAny<It.IsAnyType>(),
+                  It.IsAny<Exception>(),
+                  (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+                        Times.Exactly(2));
+        }
+
+        // 異常系：MySqlException
+        [Fact]
+        public void DeleteTest003()
+        {
+            IQueryable<Diary> data = new List<Diary>
+            {
+                new Diary(1, "たいとる１（てすと）", "ほんぶん１（てすと）"),
+                new Diary(2, "たいとる２（てすと）", "ほんぶん２（てすと）"),
+                new Diary(3, "たいとる３（てすと）", "ほんぶん３（てすと）"),
+                new Diary(4, "たいとる４（てすと）", "ほんぶん４（てすと）"),
+                new Diary(5, "たいとる５（てすと）", "ほんぶん５（てすと）"),
+                new Diary(6, "たいとる６（てすと）", "ほんぶん６（てすと）"),
+                new Diary(7, "たいとる７（てすと）", "ほんぶん７（てすと）"),
+            }.AsQueryable();
+            SetIQueryable(data);
+            mockContext.Setup(x => x.diary).Returns(mockSet.Object);
+            Diary diary = new Diary(1, "タイトル１（てすと）を更新", "ほんぶん１（てすと）を更新");
+            mockContext.Setup(x => x.Add(diary));
+            mockContext.Setup(x => x.SaveChanges()).Returns(1);
+            mockContext.Setup(x => x.SaveChanges()).Throws(mockException);
+
+            var exception = Assert.Throws<MySqlException>(() =>
+            {
+                bool result = repository.Delete(1);
+            });
+            Assert.Equal("DBエラー", exception.Message);
+
+            mockLogger.Verify(
+                x => x.Log(
+                        LogLevel.Error,
+                        It.IsAny<EventId>(),
+                        It.IsAny<It.IsAnyType>(),
+                        It.IsAny<Exception>(),
+                        (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+                Times.Exactly(2));
+        }
+
         private void SetIQueryable(IQueryable<Diary> data)
         {
             mockSet.As<IQueryable<Diary>>().Setup(x => x.Provider).Returns(data.Provider);

--- a/Diary-Sample-Test/Repositories/DiaryRepositoryTest.cs
+++ b/Diary-Sample-Test/Repositories/DiaryRepositoryTest.cs
@@ -321,13 +321,22 @@ namespace Diary_Sample_Test.Repositories
         [Fact]
         public void ReadTest003()
         {
-            Diary diary = new Diary(1, "たいとる１（てすと）", "ほんぶん１（てすと）");
-            mockContext.Setup(x => x.Add(diary));
-            mockContext.Setup(x => x.SaveChanges()).Throws(mockException);
+            IQueryable<Diary> data = new List<Diary>
+            {
+                new Diary(1, "たいとる１（てすと）", "ほんぶん１（てすと）"),
+                new Diary(2, "たいとる２（てすと）", "ほんぶん２（てすと）"),
+                new Diary(3, "たいとる３（てすと）", "ほんぶん３（てすと）"),
+                new Diary(4, "たいとる４（てすと）", "ほんぶん４（てすと）"),
+                new Diary(5, "たいとる５（てすと）", "ほんぶん５（てすと）"),
+                new Diary(6, "たいとる６（てすと）", "ほんぶん６（てすと）"),
+                new Diary(7, "たいとる７（てすと）", "ほんぶん７（てすと）"),
+            }.AsQueryable();
+            SetIQueryable(data);
+            mockContext.Setup(x => x.diary).Throws(mockException);
 
             var exception = Assert.Throws<MySqlException>(() =>
             {
-                bool result = repository.create(diary);
+                var resultList = repository.Read(1);
             });
             Assert.Equal("DBエラー", exception.Message);
             mockLogger.Verify(
@@ -357,7 +366,6 @@ namespace Diary_Sample_Test.Repositories
             SetIQueryable(data);
             mockContext.Setup(x => x.diary).Returns(mockSet.Object);
             Diary diary = new Diary(2, "タイトル２（てすと）を更新", "ほんぶん２（てすと）を更新");
-            mockContext.Setup(x => x.Add(diary));
             mockContext.Setup(x => x.SaveChanges()).Returns(1);
 
             bool result = repository.Update(diary);
@@ -382,7 +390,6 @@ namespace Diary_Sample_Test.Repositories
             SetIQueryable(data);
             mockContext.Setup(x => x.diary).Returns(mockSet.Object);
             Diary diary = new Diary(8, "タイトル８（てすと）を更新", "ほんぶん８（てすと）を更新");
-            mockContext.Setup(x => x.Add(diary));
             mockContext.Setup(x => x.SaveChanges()).Returns(1);
 
             bool result = repository.Update(diary);
@@ -415,8 +422,6 @@ namespace Diary_Sample_Test.Repositories
             SetIQueryable(data);
             mockContext.Setup(x => x.diary).Returns(mockSet.Object);
             Diary diary = new Diary(1, "タイトル１（てすと）を更新", "ほんぶん１（てすと）を更新");
-            mockContext.Setup(x => x.Add(diary));
-            mockContext.Setup(x => x.SaveChanges()).Returns(1);
             mockContext.Setup(x => x.SaveChanges()).Throws(mockException);
 
             var exception = Assert.Throws<MySqlException>(() =>
@@ -451,8 +456,6 @@ namespace Diary_Sample_Test.Repositories
             }.AsQueryable();
             SetIQueryable(data);
             mockContext.Setup(x => x.diary).Returns(mockSet.Object);
-            Diary diary = new Diary(2, "タイトル２（てすと）を更新", "ほんぶん２（てすと）を更新");
-            mockContext.Setup(x => x.Add(diary));
             mockContext.Setup(x => x.SaveChanges()).Returns(1);
 
             bool result = repository.Delete(2);
@@ -476,8 +479,6 @@ namespace Diary_Sample_Test.Repositories
             }.AsQueryable();
             SetIQueryable(data);
             mockContext.Setup(x => x.diary).Returns(mockSet.Object);
-            Diary diary = new Diary(8, "タイトル８（てすと）を更新", "ほんぶん８（てすと）を更新");
-            mockContext.Setup(x => x.Add(diary));
             mockContext.Setup(x => x.SaveChanges()).Returns(1);
 
             bool result = repository.Delete(8);
@@ -509,9 +510,6 @@ namespace Diary_Sample_Test.Repositories
             }.AsQueryable();
             SetIQueryable(data);
             mockContext.Setup(x => x.diary).Returns(mockSet.Object);
-            Diary diary = new Diary(1, "タイトル１（てすと）を更新", "ほんぶん１（てすと）を更新");
-            mockContext.Setup(x => x.Add(diary));
-            mockContext.Setup(x => x.SaveChanges()).Returns(1);
             mockContext.Setup(x => x.SaveChanges()).Throws(mockException);
 
             var exception = Assert.Throws<MySqlException>(() =>


### PR DESCRIPTION
DiaryRepositoryTest.csでのMySqlException発生時の、
mockLoggerの確認については、ネットで調べても、いまいち使い方が分からなかったので、
すみませんが、そちらのに乗っからせてもらいました。

MySqlExceptionのアサーションについては、ちょっと違うやり方にしてみました。
ちなみに、CreateTest3()などでの、MySqlExceptionのchachだと、
MySqlExceptionが発生しなかった場合に、
catchの外にAssertがないから正常終了しそうな気がしてきました。
