### PR TITLE
メニュー画面と登録画面のE2Eテスト（画面表示・イベント）を追加

### DIFF
--- a/Diary-Sample/Views/Create/Index.cshtml
+++ b/Diary-Sample/Views/Create/Index.cshtml
@@ -32,7 +32,7 @@
                 <input class="form-control form-control-lg" type="text" placeholder="タイトルを入力してください" asp-for="Title">
                 <span asp-validation-for="Title" class="text-danger"></span>
                 <br/>
-                <textarea class="form-control" id="updFormControlTextarea1" rows="15" placeholder="本文を入力してください" asp-for="Content" ></textarea>
+                <textarea class="form-control" rows="15" placeholder="本文を入力してください" asp-for="Content" ></textarea>
                 <span asp-validation-for="Content" class="text-danger"></span>
             <!-- Modal -->
                 <div class="modal fade" id="updModal" tabindex="-1" role="dialog" aria-labelledby="updModalLabel" aria-hidden="true">
@@ -42,8 +42,8 @@
                             <h5 class="modal-title" id="updModalLabel">登録します。よろしいですか？</h5>
                             </div>
                             <div class="modal-footer">
-                                <button class="btn theme_positive" asp-controller="Create" asp-action="Create" >はい</button>
-                                <button class="btn theme_cancel" data-dismiss="modal">いいえ</button>
+                                <button id="yes" class="btn theme_positive" asp-controller="Create" asp-action="Create" >はい</button>
+                                <button id="no" class="btn theme_cancel" data-dismiss="modal">いいえ</button>
                             </div>
                         </div>
                     </div>
@@ -56,7 +56,7 @@
     <br/>
     <div class="row">
         <div class="col-2">
-                <button id="update" class="btn btn-sm theme" data-toggle="modal" data-target="#updModal" >登録</button>
+                <button id="create" class="btn btn-sm theme" data-toggle="modal" data-target="#updModal" >登録</button>
             <form method="get">
                 <button id="back" class="btn btn-sm theme_cancel" asp-controller="Create" asp-action="Back" >戻る</button>
             </form>

--- a/e2e/cypress/integration/diary-sample/01_menu.spec.js
+++ b/e2e/cypress/integration/diary-sample/01_menu.spec.js
@@ -1,11 +1,44 @@
 /// <reference types="cypress" />
 
-context('Display Menu', () => {
+import HeaderTest from "./component/header";
+import FooterTest from "./component/footer";
+
+describe("メニュー", () => {
   beforeEach(() => {
-    cy.visit('/')
-  })
+    cy.visit("/");
+  });
 
-  it('Menu', () => {
+  context("画面項目", () => {
+    it("URL", () => {
+      cy.url().should("eq", Cypress.config().baseUrl + "/");
+    });
 
-  })
-})
+    it("タイトル", () => {
+      cy.title().should("eq", "メニュー");
+    });
+
+    it("ヘッダ", () => {
+      HeaderTest.test();
+    });
+
+    it("テーブル", () => {
+      cy.get(".theme_diary_title th")
+        .first()
+        .should("have.text", "No")
+        .next()
+        .should("have.text", "タイトル")
+        .next()
+        .should("have.text", "投稿日");
+    });
+
+    it("新規登録ボタン", () => {
+      cy.get("#create").should("have.text", "新規登録");
+    });
+
+    it("フッタ", () => {
+      FooterTest.test();
+    });
+  });
+
+  HeaderTest.clickTest("/");
+});

--- a/e2e/cypress/integration/diary-sample/02_create.spec.js
+++ b/e2e/cypress/integration/diary-sample/02_create.spec.js
@@ -1,15 +1,115 @@
 /// <reference types="cypress" />
 
-context('Display Menu', () => {
-  beforeEach(() => {
-    cy.visit('/')
-  })
+import HeaderTest from "./component/header";
+import FooterTest from "./component/footer";
 
-  it('Create', () => {
-    cy.get('#create').click()
-    cy.get('#Title').type('Hello world')
-    cy.get('#updFormControlTextarea1').type('Hello world')
-    cy.get('#update').click()
-    cy.get('#updModal').find('button').first().click()
-  })
-})
+describe("新規登録", () => {
+  beforeEach(() => {
+    cy.visit("/");
+    cy.get("#create").click();
+  });
+
+  context("画面項目", () => {
+    it("URL", () => {
+      cy.url().should("eq", Cypress.config().baseUrl + "/Create");
+    });
+
+    it("タイトル", () => {
+      cy.title().should("eq", "新規登録");
+    });
+
+    it("ヘッダ", () => {
+      HeaderTest.test();
+    });
+
+    it("日記-タイトル", () => {
+      cy.get("#Title").should(
+        "have.attr",
+        "placeholder",
+        "タイトルを入力してください"
+      );
+    });
+
+    it("日記-本文", () => {
+      cy.get("#Content").should(
+        "have.attr",
+        "placeholder",
+        "本文を入力してください"
+      );
+    });
+
+    it("登録ボタン", () => {
+      cy.get("#create").should("have.text", "登録");
+    });
+
+    it("戻るボタン", () => {
+      cy.get("#back").should("have.text", "戻る");
+    });
+
+    it("フッタ", () => {
+      FooterTest.test();
+    });
+  });
+
+  HeaderTest.clickTest("/Create");
+
+  context("登録", () => {
+    it("日記が登録される", () => {
+      cy.get("#Title").type("Hello world");
+      cy.get("#Content").type("Hello world");
+      cy.get("#create").click();
+      cy.get("#yes").click();
+
+      cy.url().should("eq", Cypress.config().baseUrl + "/");
+      const d = new Date();
+      cy.get(".theme_diary_content td")
+        .first()
+        .should("have.text", "1")
+        .next()
+        .should("have.text", "Hello world")
+        .next()
+        .should(
+          "have.text",
+          `${d.getFullYear()}/${(d.getMonth() + 1)
+            .toString()
+            .padStart(2, "0")}/${d.getDate().toString().padStart(2, "0")}`
+        );
+    });
+
+    it("タイトル必須エラー", () => {
+      cy.get("#Content").type("Hello world");
+      cy.get("#create").click();
+      cy.get("#yes").click();
+
+      cy.get(".field-validation-error").should(
+        "have.text",
+        "タイトルは必須です。"
+      );
+    });
+
+    it("本文必須エラー", () => {
+      cy.get("#Title").type("Hello world");
+      cy.get("#create").click();
+      cy.get("#yes").click();
+
+      cy.get(".field-validation-error").should("have.text", "本文は必須です。");
+    });
+  });
+
+  context("戻る", () => {
+    it("メニューに戻る", () => {
+      cy.get("#back").click();
+      cy.url().should("eq", Cypress.config().baseUrl + "/");
+    });
+  });
+
+  context("ダイアログ-いいえ", () => {
+    it("登録されない", () => {
+      cy.get("#Title").type("Hello world");
+      cy.get("#Content").type("Hello world");
+      cy.get("#create").click();
+      cy.get("#no").click();
+      cy.url().should("eq", Cypress.config().baseUrl + "/Create");
+    });
+  });
+});

--- a/e2e/cypress/integration/diary-sample/component/footer.js
+++ b/e2e/cypress/integration/diary-sample/component/footer.js
@@ -1,0 +1,5 @@
+export default class FooterTest {
+  static test() {
+    cy.get("footer div").should("contain.text", "© 2020 - Diary_Sample");
+  }
+}

--- a/e2e/cypress/integration/diary-sample/component/header.js
+++ b/e2e/cypress/integration/diary-sample/component/header.js
@@ -1,0 +1,54 @@
+export default class HeaderTest {
+  static test() {
+    cy.get(".navbar-brand")
+      .should("have.text", "日記")
+      .should("not.have.attr", "href");
+
+    cy.get(".nav-item").within((item) => {
+      cy.wrap(item)
+        .eq(0)
+        .children()
+        .should("have.text", "Home")
+        .should("have.attr", "href", "/");
+
+      cy.wrap(item)
+        .eq(1)
+        .children()
+        .should("have.text", "プロフィール")
+        .should("have.attr", "href", "#");
+
+      cy.wrap(item)
+        .eq(2)
+        .children()
+        .should("have.text", "設定")
+        .should("have.attr", "href", "#");
+    });
+  }
+
+  static click(index) {
+    cy.get(".nav-item").eq(index).children().click();
+  }
+
+  static clickTest(url) {
+    context("Home", () => {
+      it("メニューに遷移する", () => {
+        HeaderTest.click(0);
+        cy.url().should("eq", Cypress.config().baseUrl + "/");
+      });
+    });
+  
+    context("プロフィール", () => {
+      it("遷移なし", () => {
+        HeaderTest.click(1);
+        cy.url().should("eq", Cypress.config().baseUrl + url + "#");
+      });
+    });
+  
+    context("設定", () => {
+      it("遷移なし", () => {
+        HeaderTest.click(2);
+        cy.url().should("eq", Cypress.config().baseUrl + url + "#");
+      });
+    });
+  }
+}


### PR DESCRIPTION
# 変更内容
メニュー画面と登録画面のE2Eテスト項目を追加しました。

以下について追加しました。
- 画面項目があるか、文言が正しいかチェックするテスト
- 各ボタンの処理を実行した際の遷移先URLや画面の状態をチェックするテスト

cypressはDOMの要素がほとんど取得できるので、検証しようとすると何でも検証できてしまうので、ある程度ポイントを絞ってテスト項目を作っています。

※ヘッダやフッタのテストは共通化したので、参照画面や編集画面でもそちらをご使用ください。
※メニュー画面のページャーのテストは、ある程度データ登録しないとできないので、順番的に一番最後に作成しようと思っています。

---

上記テストによって、設計通りに画面項目が存在するか、システムが想定したふるまいをしているかをテストできますが、
画面のレイアウトが想定した通りの見た目になっているかはテストできていません。
（HTMLやCSSを修正した際に画面レイアウトに関して意図せぬところがおかしくなるケースをチェックできない）

cypressだとスクリーンキャプチャをとって比較することによって、見た目が変わっていないかをチェックするビジュアルリグレッションテストを行うことができるようで、今後はそちらも試してみる予定です。
（CSS要素を取得して１つ１つ検証することもできますが、そちらは気が遠くなるのでやりません）