### PR TITLE
管理者用ユーザ登録画面追加

### DIFF
--- a/Diary-Sample/Common/ResultType.cs
+++ b/Diary-Sample/Common/ResultType.cs
@@ -1,0 +1,15 @@
+// -----------------------------------------------------------------
+// <copyright file="ResultType.cs" company="1-system-group">
+// Copyright (c) 1-system-group. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Diary_Sample.Common
+{
+    public enum ResultType
+    {
+        None = 0,
+        Normal,
+        Warning,
+        Error
+    }
+}

--- a/Diary-Sample/Controllers/ManageController.cs
+++ b/Diary-Sample/Controllers/ManageController.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-
+using static Diary_Sample.Common.ResultType;
 namespace Diary_Sample.Controllers
 {
     [Authorize]
@@ -46,6 +46,8 @@ namespace Diary_Sample.Controllers
 
             if (!ModelState.IsValid)
             {
+                model.Notification = string.Empty;
+                model.NotificationType = None;
                 return View("CreateAccount", model);
             }
 
@@ -62,7 +64,7 @@ namespace Diary_Sample.Controllers
             {
                 // パスワード不一致エラー
                 model.Notification = "パスワードとパスワード（再入力）が不一致です。";
-                model.NotificationColor = "manage_theme_warning";
+                model.NotificationType = Error;
                 return View("CreateAccount", model);
             }
 
@@ -71,7 +73,7 @@ namespace Diary_Sample.Controllers
             {
                 // パスワードエラー
                 model.Notification = "パスワードが不正です。";
-                model.NotificationColor = "manage_theme_warning";
+                model.NotificationType = Error;
                 return View("CreateAccount", model);
             }
 
@@ -83,14 +85,14 @@ namespace Diary_Sample.Controllers
                 return View("Index", new ManageViewModel(_userManager, 1)
                 {
                     Notification = "登録が完了しました。",
-                    NotificationColor = "manage_theme_positive",
+                    NotificationType = Normal,
                 });
             }
             else
             {
                 // 登録失敗
                 model.Notification = "入力されたアカウントはすでに登録されています。";
-                model.NotificationColor = "manage_theme_warning";
+                model.NotificationType = Error;
                 return View("CreateAccount", model);
             }
         }

--- a/Diary-Sample/Models/CreateAccountViewModel.cs
+++ b/Diary-Sample/Models/CreateAccountViewModel.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.ComponentModel.DataAnnotations;
+using Diary_Sample.Common;
+using static Diary_Sample.Common.ResultType;
 
 namespace Diary_Sample.Models
 {
@@ -37,7 +39,7 @@ namespace Diary_Sample.Models
 
         // 通知
         public string Notification { get; set; } = string.Empty;
-        // 通知の色
-        public string NotificationColor { get; set; } = string.Empty;
+        // 通知の種類
+        public ResultType NotificationType { get; set; } = None;
     }
 }

--- a/Diary-Sample/Models/CreateAccountViewModel.cs
+++ b/Diary-Sample/Models/CreateAccountViewModel.cs
@@ -1,0 +1,43 @@
+// -----------------------------------------------------------------------
+// <copyright file="CreateAccountViewModel.cs" company="1-system-group">
+// Copyright (c) 1-system-group. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+using System.ComponentModel.DataAnnotations;
+
+namespace Diary_Sample.Models
+{
+    public class CreateAccountViewModel
+    {
+        // Eメールアドレス
+        [Required(ErrorMessage = "Eメールは必須です。")]
+        [EmailAddress(ErrorMessage = "Eメールが不正です")]
+        [Display(Name = "Eメール")]
+        public string Email { get; set; } = string.Empty;
+
+        // ユーザ名
+        // [Required(ErrorMessage = "ユーザ名は必須です。")]
+        // [Display(Name = "ユーザ名")]
+        // public string UserName { get; set; } = string.Empty;
+
+        // パスワード
+        [Required(ErrorMessage = "パスワードは必須です")]
+        [DataType(DataType.Password)]
+        public string Password1 { get; set; } = string.Empty;
+
+        // パスワード（再入力）
+        [Required(ErrorMessage = "パスワード（再入力）は必須です")]
+        [DataType(DataType.Password)]
+        public string Password2 { get; set; } = string.Empty;
+
+        // 電話番号
+        [Phone(ErrorMessage = "電話番号が不正です。")]
+        [Display(Name = "電話番号")]
+        public string? PhoneNumber { get; set; } = string.Empty;
+
+        // 通知
+        public string Notification { get; set; } = string.Empty;
+        // 通知の色
+        public string NotificationColor { get; set; } = string.Empty;
+    }
+}

--- a/Diary-Sample/Models/ManageViewModel.cs
+++ b/Diary-Sample/Models/ManageViewModel.cs
@@ -33,12 +33,16 @@ namespace Diary_Sample.Models
         public List<UserViewModel> Users { get; } = new List<UserViewModel>();
         // ページ管理
         public PageViewModel Page { get; }
+        // 通知
+        public string Notification { get; set; } = string.Empty;
+        // 通知の色
+        public string NotificationColor { get; set; } = string.Empty;
         // UserMangerから全ユーザを取得する
         private static List<UserViewModel> getAllUsers(UserManager<IdentityUser> userManager)
         {
             using (UserManager<IdentityUser>? um = userManager ?? throw new ArgumentNullException(nameof(userManager)))
             {
-                return (from user in um.Users select new UserViewModel(user)).ToList<UserViewModel>();
+                return (from user in um.Users orderby user.Email select new UserViewModel(user)).ToList<UserViewModel>();
             }
         }
         // 指定ページのユーザリストを取得する

--- a/Diary-Sample/Models/ManageViewModel.cs
+++ b/Diary-Sample/Models/ManageViewModel.cs
@@ -6,7 +6,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Diary_Sample.Common;
 using Microsoft.AspNetCore.Identity;
+using static Diary_Sample.Common.ResultType;
 
 namespace Diary_Sample.Models
 {
@@ -35,8 +37,8 @@ namespace Diary_Sample.Models
         public PageViewModel Page { get; }
         // 通知
         public string Notification { get; set; } = string.Empty;
-        // 通知の色
-        public string NotificationColor { get; set; } = string.Empty;
+        // 通知の種類
+        public ResultType NotificationType { get; set; } = None;
         // UserMangerから全ユーザを取得する
         private static List<UserViewModel> getAllUsers(UserManager<IdentityUser> userManager)
         {

--- a/Diary-Sample/Views/Manage/CreateAccount.cshtml
+++ b/Diary-Sample/Views/Manage/CreateAccount.cshtml
@@ -1,0 +1,91 @@
+@using System.Globalization
+@{
+    ViewData["Title"] = "アカウント登録";
+}
+@model CreateAccountViewModel
+<h3><img src="./../lib/bootstrap-icons/gear.svg" alt="" width="32" height="32" title="management">管理</h3>
+<div>
+    <h4></h4>
+    <hr />
+    <div class="row">
+        <div class="col-md-3">
+            <ul class="nav nav-pills flex-column">
+                <li class="nav-item"><a class="nav-link manage_theme" id="manage_account" asp-area="" asp-controller="Manage" asp-action="Index">アカウント管理</a></li>
+            </ul>
+        </div>
+        <div class="col-md-5">
+            <form asp-controller="CreateAccount" asp-action="Create" method="post">
+                <div class="d-grid gap-3 border-bottom">
+                    @* <div class="form-group p-2">
+                        <label>
+                        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-person-fill icon-color" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                        <path fill-rule="evenodd" d="M3 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1H3zm5-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"/>
+                        </svg>
+                            ユーザ名
+                        </label>
+                        <input class="form-control" type="text" placeholder="名前を入力してください" asp-for="UserName">
+                        <span asp-validation-for="UserName" class="text-danger"></span>
+                    </div> *@
+                    <div class="form-group p-1">
+                        <label>
+                        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-envelope-fill icon-color" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                        <path fill-rule="evenodd" d="M.05 3.555A2 2 0 0 1 2 2h12a2 2 0 0 1 1.95 1.555L8 8.414.05 3.555zM0 4.697v7.104l5.803-3.558L0 4.697zM6.761 8.83l-6.57 4.027A2 2 0 0 0 2 14h12a2 2 0 0 0 1.808-1.144l-6.57-4.027L8 9.586l-1.239-.757zm3.436-.586L16 11.801V4.697l-5.803 3.546z"/>
+                        </svg>
+                            Eメールアドレス
+                        </label>
+                        <input class="form-control" type="text" placeholder="メールアドレスを入力してください" asp-for="Email">
+                        <span asp-validation-for="Email" class="text-danger"></span>
+                    </div>
+                    <div class="form-group p-1">
+                        <label> <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-telephone-fill icon-color" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                        <path fill-rule="evenodd" d="M2.267.98a1.636 1.636 0 0 1 2.448.152l1.681 2.162c.309.396.418.913.296 1.4l-.513 2.053a.636.636 0 0 0 .167.604L8.65 9.654a.636.636 0 0 0 .604.167l2.052-.513a1.636 1.636 0 0 1 1.401.296l2.162 1.681c.777.604.849 1.753.153 2.448l-.97.97c-.693.693-1.73.998-2.697.658a17.47 17.47 0 0 1-6.571-4.144A17.47 17.47 0 0 1 .639 4.646c-.34-.967-.035-2.004.658-2.698l.97-.969z"/>
+                        </svg> 電話番号 </label>
+                        <input class="form-control" type="tel" placeholder="電話番号を入力してください" asp-for="PhoneNumber">
+                        <span asp-validation-for="PhoneNumber" class="text-danger"></span>
+                    </div>
+                </div>
+                <div class="d-grid gap-2">
+                    <div class="form-group p-1">
+                        <label>
+                        パスワード 
+                        </label>
+                        <input class="form-control" type="password" placeholder="パスワードを入力してください" asp-for="Password1">
+                        <span asp-validation-for="Password1" class="text-danger"></span>
+                    </div>
+                    <div class="form-group p-1">
+                        <label>
+                        パスワード（再入力） 
+                        </label>
+                        <input class="form-control" type="password" placeholder="パスワード（再入力）を入力してください" asp-for="Password2">
+                        <span asp-validation-for="Password2" class="text-danger"></span>
+                    </div>
+                    <span class="password_explain">
+                    ※パスワードは6文字以上、英字大文字・英字小文字・数字・記号を含んでいる必要があります。
+                    </span>
+                </div>
+                <!-- Modal -->
+                <div class="modal fade" id="updModal" tabindex="-1" role="dialog" aria-labelledby="updModalLabel" aria-hidden="true">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header manage_theme_positive">
+                            <h5 class="modal-title" id="updModalLabel">登録します。よろしいですか？</h5>
+                            </div>
+                            <div class="modal-footer">
+                                <button id="yes" class="btn manage_theme_positive" asp-controller="Manage" asp-action="Create" >はい</button>
+                                <button id="no" class="btn manage_theme_cancel" data-dismiss="modal">いいえ</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </form>
+            <div class="form-group p-2">
+                <button id="create" class="btn btn-sm manage_theme" data-toggle="modal" data-target="#updModal" >登録</button>
+                <form method="get">
+                    <button id="back" class="btn btn-sm manage_theme_cancel" asp-controller="Manage" asp-action="Index" >戻る</button>
+                </form>
+            </div>
+        </div>
+        <div class="col-md-4">
+        </div>
+    </div>
+</div>

--- a/Diary-Sample/Views/Manage/index.cshtml
+++ b/Diary-Sample/Views/Manage/index.cshtml
@@ -76,9 +76,12 @@ var confirmed = item.EmailConfirmed ? "済" : "未";
                 </form>
             </div>
             <div class="row">
-                <div class="col-1">
+                <div class="col-2">
+                    <form method="get">
+                        <button id="newEntry" class="btn btn-sm manage_theme" asp-controller="Manage" asp-action="NewEntry">登録</button>
+                    </form> 
                 </div>
-                <div class="col-11">
+                <div class="col-10">
                     <ul class="pagination justify-content-end">
 @if(Model.Page.existPrevPage()){
                         <li class="page-item">

--- a/Diary-Sample/Views/Shared/_ManageLayout.cshtml
+++ b/Diary-Sample/Views/Shared/_ManageLayout.cshtml
@@ -44,6 +44,9 @@
             </div>
         </nav>
     </header>
+    @if(Model.Notification != string.Empty){
+    <partial name="_Toast" />
+    }
     <div class="container">
         <main class="pb-3">
             @RenderBody()

--- a/Diary-Sample/Views/Shared/_ManageLayout.cshtml
+++ b/Diary-Sample/Views/Shared/_ManageLayout.cshtml
@@ -1,4 +1,5 @@
-﻿<!DOCTYPE html>
+﻿@using Diary_Sample.Common
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">
@@ -44,7 +45,7 @@
             </div>
         </nav>
     </header>
-    @if(Model.Notification != string.Empty){
+    @if(Model.NotificationType != ResultType.None){
     <partial name="_Toast" />
     }
     <div class="container">

--- a/Diary-Sample/Views/Shared/_Toast.cshtml
+++ b/Diary-Sample/Views/Shared/_Toast.cshtml
@@ -1,0 +1,21 @@
+<!-- toast -->
+<div id="message" class="toast" data-delay="3000" role="alert" aria-live="assertive" aria-atomic="true">
+    <div id="toast-header" class="toast-header @Model.NotificationColor">
+    <strong class="mr-auto">Notification</strong>
+    <small>just now</small>
+    <button type="button" class="ml-2 mb-1 close" data-dismiss="toast" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+    </button>
+    </div>
+    <div class="toast-body">
+        <span id="toast_message"></span>
+    </div>
+</div>
+
+<script>
+    window.onload = function() {
+
+        $('#toast_message').text("@Html.Raw(Model.Notification)");
+        $('#message').toast('show');
+    }
+</script>

--- a/Diary-Sample/Views/Shared/_Toast.cshtml
+++ b/Diary-Sample/Views/Shared/_Toast.cshtml
@@ -1,17 +1,33 @@
 <!-- toast -->
+@using Diary_Sample.Common
 <div id="message" class="toast" data-delay="3000" role="alert" aria-live="assertive" aria-atomic="true">
-    <div id="toast-header" class="toast-header @Model.NotificationColor">
+@{
+    var type = "";
+    switch(Model.NotificationType) {
+        case ResultType.Normal :
+            type = "notification_theme_normal";
+            break;
+        case ResultType.Warning :
+            type = "notification_theme_warning";
+            break;
+        case ResultType.Error:
+            type = "notification_theme_error";
+            break;
+        default:
+            break;
+    }
+    <div id="toast-header" class="toast-header @type">
     <strong class="mr-auto">Notification</strong>
     <small>just now</small>
     <button type="button" class="ml-2 mb-1 close" data-dismiss="toast" aria-label="Close">
         <span aria-hidden="true">&times;</span>
     </button>
     </div>
+}
     <div class="toast-body">
         <span id="toast_message"></span>
     </div>
 </div>
-
 <script>
     window.onload = function() {
 

--- a/Diary-Sample/Views/_ViewStart.cshtml
+++ b/Diary-Sample/Views/_ViewStart.cshtml
@@ -5,7 +5,7 @@
   {
     Layout = "_AuthLayout";
   }
-  else if(controller == "Manage")
+  else if(controller == "Manage" || controller == "CreateAccount")
   {
     Layout = "_ManageLayout";
   }

--- a/Diary-Sample/wwwroot/css/manage.css
+++ b/Diary-Sample/wwwroot/css/manage.css
@@ -8,6 +8,14 @@ body {
 form {
     display: inline;
 }
+.notification_theme_normal {
+    color:white;
+    background-color: rgb(103, 145, 209);
+}
+.notification_theme_error {
+    color: white;
+    background-color: rgb(255, 174, 181);
+}
 
 /**
 * 管理

--- a/Diary-Sample/wwwroot/css/manage.css
+++ b/Diary-Sample/wwwroot/css/manage.css
@@ -5,6 +5,9 @@ body {
 ::selection {
     background: rgba(19, 94, 255, 0.411);
 }
+form {
+    display: inline;
+}
 
 /**
 * 管理
@@ -21,6 +24,32 @@ body {
 }
 .manage_theme::selection {
     color:white;
+}
+.manage_theme_positive {
+    color:white;
+    background-color: rgb(103, 145, 209);
+}
+.manage_theme_positive:hover {
+    color:white;
+    background-color: rgb(103, 145, 209);
+}
+.manage_theme_warning {
+    color: white;
+    background-color: rgb(255, 174, 181);
+}
+.manage_theme_warning:hover {
+    color: white;
+    background-color: rgb(255, 174, 181);
+}
+.manage_theme_cancel{
+    border : 1px solid darkgray;
+    color: black;
+    background-color: white;
+}
+.manage_theme_cancel:hover {
+    border : 1px solid darkgray;
+    color: black;
+    background-color: white;
 }
 
 
@@ -81,4 +110,7 @@ table.account_list td {
 
 .user_email {
     color: rgb(38, 8, 209) !important;
+}
+.password_explain {
+    font-size: 0.5rem;
 }


### PR DESCRIPTION
# 変更内容
管理者用ユーザ管理画面から登録ボタンクリックで、ユーザ登録画面へ遷移できるようにしました。
![スクリーンショット 2021-05-23 135522](https://user-images.githubusercontent.com/15532048/119248968-f3552500-bbcf-11eb-877a-a00844ced96f.png)

---

# 詳細
- ユーザを登録すると`AspNetUsers`テーブルにレコードが登録されます。
- 以下はまだ対応していません。（今後対応予定です）
  - ユーザ名とEメールアドレスは同じもの扱いとなっています。
  - 登録時の確認メール送信処理は未実装です。（現時点では登録と同時にメール確認済み扱いで登録されます）
  - 管理者用として作成していますが、管理者権限などの機能は未実装です。（だれでも管理者用メニューが使えます）