### PR TITLE
データベースのデータをローカルに保持するように修正

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: db volume permission change
+        run: chmod 777 Diary-Sample/docker/db/data
       - name: db startup
         run: docker-compose -f Diary-Sample/docker-compose.yml up -d
       - name: app build

--- a/.gitignore
+++ b/.gitignore
@@ -702,3 +702,8 @@ MigrationBackup/
 
 # reg-suit
 *.reg
+
+# Docker Data Folder
+!/Diary-Sample/docker/db/data
+/Diary-Sample/docker/db/data/*
+!/Diary-Sample/docker/db/data/.gitkeep

--- a/Diary-Sample/docker-compose.yml
+++ b/Diary-Sample/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       MYSQL_PASSWORD: password
       TZ: 'Asia/Tokyo'
     volumes:
-    #- ./docker/db/data:/var/lib/mysql
+    - ./docker/db/data:/var/lib/mysql
     - ./docker/db/sql:/docker-entrypoint-initdb.d
     ports:
     - 3306:3306


### PR DESCRIPTION
# 変更内容
docker-composeするたびに.AspNetCoreIdentity系のテーブルを移行する必要がありましたが、
ローカルにDBの状態を保持して`docker-compose down`しても、DBデータを消さないように修正しました。

`docker-compose up -d`を実施すると、`docker/db/data`フォルダが作成され、そこにデータベースのデータが保存されるようになります。

.AspNetCoreIdentity系のテーブルが作成されていない場合は、今まで通り以下のコマンドでテーブルを作成してください。
```
dotnet ef database update --project Diary-Sample
```
