### PR TITLE
モバイルアプリ用REST APIの作成（日記の情報一覧取得・件数取得）

### DIFF
--- a/Diary-Sample-Test/Services/MenuServiceTest.cs
+++ b/Diary-Sample-Test/Services/MenuServiceTest.cs
@@ -17,14 +17,14 @@ namespace Diary_Sample_Test.Services
 {
     public class MenuServiceTest
     {
-        private readonly Mock<ILogger<MenuService>> mockLogger;
         private readonly Mock<IDiaryRepository> mockRepository;
         private readonly MenuService service;
         public MenuServiceTest()
         {
-            mockLogger = new Mock<ILogger<MenuService>>();
             mockRepository = new Mock<IDiaryRepository>();
-            service = new MenuService(mockLogger.Object, mockRepository.Object);
+            service = new MenuService(
+                new Mock<ILogger<MenuService>>().Object,
+                new SharedService(new Mock<ILogger<ISharedService>>().Object, mockRepository.Object));
         }
         [Fact]
         public void IndexTest1()

--- a/Diary-Sample/Analyzers.ruleset
+++ b/Diary-Sample/Analyzers.ruleset
@@ -17,5 +17,6 @@
     <Rule Id="SA1516" Action="None" />
     <Rule Id="SA1600" Action="None" />
     <Rule Id="SA1601" Action="None" />
+    <Rule Id="SA1629" Action="None" />
   </Rules>
 </RuleSet>

--- a/Diary-Sample/Controllers/ApiController.cs
+++ b/Diary-Sample/Controllers/ApiController.cs
@@ -3,6 +3,8 @@
 // Copyright (c) 1-system-group. All rights reserved.
 // </copyright>
 // -----------------------------------------------------------------------
+using System.Collections.Generic;
+using Diary_Sample.Models;
 using Diary_Sample.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -12,7 +14,8 @@ namespace Diary_Sample.Controllers
 {
     [ApiController]
     [Route("api/v1/[action]")]
-    public class ApiController : ControllerBase
+    [Produces("application/json")]
+    public class ApiController : ControllerBase, IApiController
     {
         private readonly ILogger<ApiController> _logger;
         private readonly IApiService _service;
@@ -21,10 +24,14 @@ namespace Diary_Sample.Controllers
             _logger = logger;
             _service = service;
         }
+
+        [HttpGet("{page}")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(BadRequestResult), StatusCodes.Status400BadRequest)]
+        public ActionResult<List<DiaryRow>> Lists(int page) => page > 0 ? (ActionResult)Ok(_service.Lists(page)) : BadRequest();
+
         [HttpGet]
-        [Route("{page}")]
-        public IActionResult Lists(int page) => page > 0 ? (IActionResult)Ok(_service.Lists(page)) : BadRequest();
-        [HttpGet]
-        public IActionResult Counts() => Ok(_service.Counts());
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public ActionResult<int> Counts() => Ok(_service.Counts());
     }
 }

--- a/Diary-Sample/Controllers/ApiController.cs
+++ b/Diary-Sample/Controllers/ApiController.cs
@@ -1,0 +1,30 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApiController.cs" company="1-system-group">
+// Copyright (c) 1-system-group. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+using Diary_Sample.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Diary_Sample.Controllers
+{
+    [ApiController]
+    [Route("api/v1/[action]")]
+    public class ApiController : ControllerBase
+    {
+        private readonly ILogger<ApiController> _logger;
+        private readonly IApiService _service;
+        public ApiController(ILogger<ApiController> logger, IApiService service)
+        {
+            _logger = logger;
+            _service = service;
+        }
+        [HttpGet]
+        [Route("{page}")]
+        public IActionResult Lists(int page) => page > 0 ? (IActionResult)Ok(_service.Lists(page)) : BadRequest();
+        [HttpGet]
+        public IActionResult Counts() => Ok(_service.Counts());
+    }
+}

--- a/Diary-Sample/Controllers/IApiController.cs
+++ b/Diary-Sample/Controllers/IApiController.cs
@@ -1,0 +1,42 @@
+// -----------------------------------------------------------------------
+// <copyright file="IApiController.cs" company="1-system-group">
+// Copyright (c) 1-system-group. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Collections.Generic;
+using Diary_Sample.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Diary_Sample.Controllers
+{
+    public interface IApiController
+    {
+        /// <summary>
+        /// 日記の情報一覧を取得する
+        /// </summary>
+        /// <remarks>
+        /// 1ページの件数は10件。ページ番号は1以上の値を指定。存在しないページ番号を指定すると空リストが返却される。
+        /// </remarks>
+        /// <param name="page">ページ番号</param>
+        /// <returns>日記の情報リスト</returns>
+        /// <response code="200">OK 日記の情報リスト</response>
+        /// <response code="400">NG 不正なページ指定</response>
+        [HttpGet("{page}")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(BadRequestResult), StatusCodes.Status400BadRequest)]
+        public ActionResult<List<DiaryRow>> Lists(int page);
+
+        /// <summary>
+        /// 日記の件数を取得する
+        /// </summary>
+        /// <remarks>
+        /// 登録されている日記の件数を取得する。本件数から何ページ存在するか判断する。
+        /// </remarks>
+        /// <returns>日記の件数</returns>
+        /// <response code="200">OK 日記の件数</response>
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public ActionResult<int> Counts();
+    }
+}

--- a/Diary-Sample/Diary-Sample.csproj
+++ b/Diary-Sample/Diary-Sample.csproj
@@ -7,29 +7,32 @@
     <CodeAnalysisRuleSet>Analyzers.ruleset</CodeAnalysisRuleSet>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.8"/>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.8"/>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8"/>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4"/>
-    <PackageReference Include="MySql.Data.EntityFrameworkCore" Version="8.0.21"/>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118"/>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0"/>
-    <PackageReference Include="AspNetCore.RouteAnalyzer" Version="0.5.3"/>
-    <PackageReference Include="SendGrid" Version="9.22.0"/>
-    <PackageReference Include="SendGrid.Extensions.DependencyInjection" Version="1.0.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.1"/>
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1"/>
-    <AdditionalFiles Include="stylecop.json" Link="stylecop.json"/>
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
+    <PackageReference Include="MySql.Data.EntityFrameworkCore" Version="8.0.21" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.12.1" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
+    <PackageReference Include="AspNetCore.RouteAnalyzer" Version="0.5.3" />
+    <PackageReference Include="SendGrid" Version="9.22.0" />
+    <PackageReference Include="SendGrid.Extensions.DependencyInjection" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />
+    <AdditionalFiles Include="stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 </Project>

--- a/Diary-Sample/Models/DiaryRow.cs
+++ b/Diary-Sample/Models/DiaryRow.cs
@@ -1,0 +1,50 @@
+// -----------------------------------------------------------------------
+// <copyright file="DiaryRow.cs" company="1-system-group">
+// Copyright (c) 1-system-group. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Globalization;
+
+namespace Diary_Sample.Models
+{
+    public readonly struct DiaryRow : IEquatable<DiaryRow>
+    {
+        public string Id { get; }
+        public string Title { get; }
+        public string PostDate { get; }
+        public DiaryRow(int id, string title, DateTime post_date)
+        {
+            CultureInfo cultureJp = CultureInfo.CreateSpecificCulture("ja-JP");
+
+            Id = id.ToString("D", cultureJp);
+            Title = title;
+            PostDate = post_date.ToString("yyyy/MM/dd", cultureJp);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
+        public bool Equals(DiaryRow other)
+        {
+            return Id == other.Id && Title == other.Title && PostDate == other.PostDate;
+        }
+
+        public static bool operator ==(DiaryRow left, DiaryRow right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(DiaryRow left, DiaryRow right)
+        {
+            return !(left == right);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is DiaryRow row && Equals(row);
+        }
+    }
+}

--- a/Diary-Sample/Models/MenuViewModel.cs
+++ b/Diary-Sample/Models/MenuViewModel.cs
@@ -3,9 +3,7 @@
 // Copyright (c) 1-system-group. All rights reserved.
 // </copyright>
 // -----------------------------------------------------------------------
-using System;
 using System.Collections.Generic;
-using System.Globalization;
 
 namespace Diary_Sample.Models
 {
@@ -25,45 +23,5 @@ namespace Diary_Sample.Models
         public PageViewModel Page { get; }
         // 通知
         public string Notification { get; set; } = string.Empty;
-    }
-
-    public readonly struct DiaryRow : IEquatable<DiaryRow>
-    {
-        public string Id { get; }
-        public string Title { get; }
-        public string PostDate { get; }
-        public DiaryRow(int id, string title, DateTime post_date)
-        {
-            CultureInfo cultureJp = CultureInfo.CreateSpecificCulture("ja-JP");
-
-            Id = id.ToString("D", cultureJp);
-            Title = title;
-            PostDate = post_date.ToString("yyyy/MM/dd", cultureJp);
-        }
-
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
-
-        public bool Equals(DiaryRow other)
-        {
-            return Id == other.Id && Title == other.Title && PostDate == other.PostDate;
-        }
-
-        public static bool operator ==(DiaryRow left, DiaryRow right)
-        {
-            return left.Equals(right);
-        }
-
-        public static bool operator !=(DiaryRow left, DiaryRow right)
-        {
-            return !(left == right);
-        }
-
-        public override bool Equals(object? obj)
-        {
-            return obj is DiaryRow row && Equals(row);
-        }
     }
 }

--- a/Diary-Sample/Services/ApiService.cs
+++ b/Diary-Sample/Services/ApiService.cs
@@ -1,0 +1,26 @@
+// -----------------------------------------------------------------------
+// <copyright file="ApiService.cs" company="1-system-group">
+// Copyright (c) 1-system-group. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Collections.Generic;
+using Diary_Sample.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Diary_Sample.Services
+{
+    public class ApiService : IApiService
+    {
+        private const int PageCount = 10;
+        private readonly ILogger<ApiService> _logger;
+        private readonly ISharedService _service;
+
+        public ApiService(ILogger<ApiService> logger, ISharedService service)
+        {
+            _logger = logger;
+            _service = service;
+        }
+        public List<DiaryRow> Lists(int page) => _service.Lists(page, PageCount);
+        public int Counts() => _service.Counts();
+    }
+}

--- a/Diary-Sample/Services/IApiService.cs
+++ b/Diary-Sample/Services/IApiService.cs
@@ -1,0 +1,16 @@
+// -----------------------------------------------------------------------
+// <copyright file="IApiService.cs" company="1-system-group">
+// Copyright (c) 1-system-group. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Collections.Generic;
+using Diary_Sample.Models;
+
+namespace Diary_Sample.Services
+{
+    public interface IApiService
+    {
+        public List<DiaryRow> Lists(int page);
+        public int Counts();
+    }
+}

--- a/Diary-Sample/Services/ISharedService.cs
+++ b/Diary-Sample/Services/ISharedService.cs
@@ -1,0 +1,16 @@
+// -----------------------------------------------------------------------
+// <copyright file="ISharedService.cs" company="1-system-group">
+// Copyright (c) 1-system-group. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Collections.Generic;
+using Diary_Sample.Models;
+
+namespace Diary_Sample.Services
+{
+    public interface ISharedService
+    {
+        public List<DiaryRow> Lists(int page, int count);
+        public int Counts();
+    }
+}

--- a/Diary-Sample/Services/MenuService.cs
+++ b/Diary-Sample/Services/MenuService.cs
@@ -15,12 +15,12 @@ namespace Diary_Sample.Services
     {
         private const int InitialPage = 1;
         private readonly ILogger<MenuService> _logger;
-        private readonly IDiaryRepository _repository;
+        private readonly ISharedService _service;
 
-        public MenuService(ILogger<MenuService> logger, IDiaryRepository repository)
+        public MenuService(ILogger<MenuService> logger, ISharedService service)
         {
             _logger = logger;
-            _repository = repository;
+            _service = service;
         }
 
         public MenuViewModel Index(string notification)
@@ -36,10 +36,8 @@ namespace Diary_Sample.Services
         private MenuViewModel createModel(int page, string notification)
         {
             return new MenuViewModel(
-                _repository.read(page, MenuViewModel.PageCount)
-                .Select(diary => new DiaryRow(diary.id, diary.title, diary.post_date))
-                .ToList(),
-                _repository.readCount(),
+                _service.Lists(page, MenuViewModel.PageCount),
+                _service.Counts(),
                 page,
                 notification);
         }

--- a/Diary-Sample/Services/SharedService.cs
+++ b/Diary-Sample/Services/SharedService.cs
@@ -1,0 +1,31 @@
+// -----------------------------------------------------------------------
+// <copyright file="SharedService.cs" company="1-system-group">
+// Copyright (c) 1-system-group. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Collections.Generic;
+using System.Linq;
+using Diary_Sample.Models;
+using Diary_Sample.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace Diary_Sample.Services
+{
+    public class SharedService : ISharedService
+    {
+        private readonly ILogger<ISharedService> _logger;
+        private readonly IDiaryRepository _repository;
+
+        public SharedService(ILogger<ISharedService> logger, IDiaryRepository repository)
+        {
+            _logger = logger;
+            _repository = repository;
+        }
+
+        public List<DiaryRow> Lists(int page, int count) =>
+                _repository.read(page, count)
+                .Select(diary => new DiaryRow(diary.id, diary.title, diary.post_date))
+                .ToList();
+        public int Counts() => _repository.readCount();
+    }
+}

--- a/Diary-Sample/Startup.cs
+++ b/Diary-Sample/Startup.cs
@@ -43,6 +43,8 @@ namespace Diary_Sample
             services.AddSingleton<ICreateService, CreateService>();
             services.AddSingleton<IReferService, ReferService>();
             services.AddSingleton<IEditService, EditService>();
+            services.AddSingleton<IApiService, ApiService>();
+            services.AddSingleton<ISharedService, SharedService>();
             services.AddSingleton<IDiaryRepository, DiaryRepository>();
             services.AddSingleton<DiarySampleContext>();
 
@@ -128,6 +130,7 @@ namespace Diary_Sample
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapRazorPages();
+                // endpoints.MapControllers();
                 endpoints.MapControllerRoute(
                     name: "default",
                     pattern: "{controller=Auth}/{action=Index}");

--- a/Diary-Sample/Startup.cs
+++ b/Diary-Sample/Startup.cs
@@ -101,6 +101,23 @@ namespace Diary_Sample
                 // セッションストアにRedisTicketStoreを使用する
                 options.SessionStore = services.BuildServiceProvider().GetRequiredService<RedisTicketStore>();
             });
+
+            // Swagger
+            services.AddSwaggerDocument(config =>
+            {
+                config.PostProcess = document =>
+                {
+                    document.Info.Version = "v1";
+                    document.Info.Title = "Diary-Sample API";
+                    document.Info.Description = "ASP.NET Core web API";
+                    document.Info.Contact = new NSwag.OpenApiContact
+                    {
+                        Name = "1-system-group",
+                        Email = string.Empty,
+                        Url = "https://github.com/1-system-group/Diary-Sample",
+                    };
+                };
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -127,10 +144,13 @@ namespace Diary_Sample
             app.UseAuthentication();
             app.UseAuthorization();
 
+            // Swagger generator・Swagger UI middlewares
+            app.UseOpenApi();
+            app.UseSwaggerUi3();
+
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapRazorPages();
-                // endpoints.MapControllers();
                 endpoints.MapControllerRoute(
                     name: "default",
                     pattern: "{controller=Auth}/{action=Index}");


### PR DESCRIPTION
# 変更内容
モバイルアプリから呼び出すための以下のREST APIを作成しました。
- 日記の情報一覧取得
- 日記の件数取得

日記の一覧を表示するためのAPIです。

URLはそれぞれ以下となります。
- 日記の情報一覧取得
   https://localhost:5001/api/v1/lists/{ページ番号}
- 日記の件数取得
   https://localhost:5001/api/v1/counts

モバイルアプリの日記一覧にはページャはありませんが、
下にスクロールしていくごとにバックエンドにアクセスして10件ずつ日記を取得するイメージでいます。

---

作成したAPIのAPIドキュメントを作成しました。
アプリを起動し、以下URLでアクセスできます。
https://localhost:5001/swagger

![スクリーンショット 2021-07-25 181638](https://user-images.githubusercontent.com/15532048/126894102-c7e5d162-36f0-4db0-a6ef-6e208c579105.png)

---
# 変更内容の詳細
- APIを追加するうえで、API用のControllerクラス・Serviceクラスを追加するとともに、WebアプリとAPIでDBアクセス処理を共通化できるようにSharedServiceを作成しています。
- もともとMenuViewModelクラスの内部構造体として持っていた'DiaryRow'を、APIの出力としても使用できるように外だししました。
- APIドキュメントを作成するためにインターフェースIApiControllerを作成しています。