### PR TITLE
モバイル用API_日記情報の取得

### DIFF
--- a/Diary-Sample-Test/Services/ReferServiceTest.cs
+++ b/Diary-Sample-Test/Services/ReferServiceTest.cs
@@ -14,12 +14,12 @@ namespace Diary_Sample_Test.Services
     public class ReferServiceTest
     {
         private readonly Mock<IDiaryRepository> mockRepository;
-        private readonly SharedService sharedService;
+        private SharedService sharedService;
 
         public ReferServiceTest()
         {
             mockRepository = new Mock<IDiaryRepository>();
-            sharedService = new SharedService(new Mock<ILogger<ISharedService>>().Object, mockRepository.Object);
+            //sharedService = new SharedService(new Mock<ILogger<ISharedService>>().Object, mockRepository.Object);
         }
 
         // 正常系：レコード取得成功
@@ -29,7 +29,9 @@ namespace Diary_Sample_Test.Services
             var diaryList = new List<Diary>();
             diaryList.Add(new Diary(1, "たいとる（てすと）", "ほんぶん（てすと）"));
             mockRepository.Setup(x => x.Read(1)).Returns(diaryList);
-            var service = new ReferService(mockRepository.Object, sharedService);
+
+            sharedService = new SharedService(new Mock<ILogger<ISharedService>>().Object, mockRepository.Object);
+            var service = new ReferService(sharedService);
 
             var result = service.GetDiary(1);
             var model = Assert.IsType<ReferViewModel>(result);
@@ -44,7 +46,9 @@ namespace Diary_Sample_Test.Services
         {
             var diaryList = new List<Diary>();
             mockRepository.Setup(x => x.Read(1)).Returns(diaryList);
-            var service = new ReferService(mockRepository.Object, sharedService);
+            sharedService = new SharedService(new Mock<ILogger<ISharedService>>().Object, mockRepository.Object);
+
+            var service = new ReferService(sharedService);
 
             var result = service.GetDiary(1);
 

--- a/Diary-Sample-Test/Services/ReferServiceTest.cs
+++ b/Diary-Sample-Test/Services/ReferServiceTest.cs
@@ -14,10 +14,12 @@ namespace Diary_Sample_Test.Services
     public class ReferServiceTest
     {
         private readonly Mock<IDiaryRepository> mockRepository;
+        private readonly SharedService sharedService;
 
         public ReferServiceTest()
         {
             mockRepository = new Mock<IDiaryRepository>();
+            sharedService = new SharedService(new Mock<ILogger<ISharedService>>().Object, mockRepository.Object);
         }
 
         // 正常系：レコード取得成功
@@ -27,7 +29,7 @@ namespace Diary_Sample_Test.Services
             var diaryList = new List<Diary>();
             diaryList.Add(new Diary(1, "たいとる（てすと）", "ほんぶん（てすと）"));
             mockRepository.Setup(x => x.Read(1)).Returns(diaryList);
-            var service = new ReferService(mockRepository.Object);
+            var service = new ReferService(mockRepository.Object, sharedService);
 
             var result = service.GetDiary(1);
             var model = Assert.IsType<ReferViewModel>(result);
@@ -42,7 +44,7 @@ namespace Diary_Sample_Test.Services
         {
             var diaryList = new List<Diary>();
             mockRepository.Setup(x => x.Read(1)).Returns(diaryList);
-            var service = new ReferService(mockRepository.Object);
+            var service = new ReferService(mockRepository.Object, sharedService);
 
             var result = service.GetDiary(1);
 

--- a/Diary-Sample/Controllers/ApiController.cs
+++ b/Diary-Sample/Controllers/ApiController.cs
@@ -33,5 +33,19 @@ namespace Diary_Sample.Controllers
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public ActionResult<int> Counts() => Ok(_service.Counts());
+
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(DiaryModel), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(NotFoundResult), StatusCodes.Status404NotFound)]
+        public ActionResult<DiaryModel> Diary(int id)
+        {
+            DiaryModel? diary = null;
+
+            if (_service.Diary(id, ref diary))
+            {
+                return Ok(diary);
+            }
+            return NotFound();
+        }
     }
 }

--- a/Diary-Sample/Controllers/IApiController.cs
+++ b/Diary-Sample/Controllers/IApiController.cs
@@ -38,5 +38,21 @@ namespace Diary_Sample.Controllers
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public ActionResult<int> Counts();
+
+        /// <summary>
+        /// 日記を取得する
+        /// </summary>
+        /// <remarks>
+        /// 登録されている日記のうち、引数のid(連番)に紐づく日記の情報を取得する。
+        /// id(連番)に紐づく日記が見つからない場合、404(NotFound)を返す。
+        /// </remarks>
+        /// <param name="id">連番</param>
+        /// <returns>日記</returns>
+        /// <response code="200">OK 日記</response>
+        /// <response code="404">NG 日記</response>
+        [HttpGet("{id}")]
+        [ProducesResponseType(typeof(DiaryModel), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(NotFoundResult), StatusCodes.Status404NotFound)]
+        public ActionResult<DiaryModel> Diary(int id);
     }
 }

--- a/Diary-Sample/Models/DiaryModel.cs
+++ b/Diary-Sample/Models/DiaryModel.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Diary_Sample.Models
+{
+    public class DiaryModel
+    {
+        public DiaryModel()
+        {
+        }
+        public DiaryModel(int id, string title, string content)
+        {
+            Id = id.ToString();
+            Title = title;
+            Content = content;
+        }
+
+        public string Id { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
+    }
+}

--- a/Diary-Sample/Services/ApiService.cs
+++ b/Diary-Sample/Services/ApiService.cs
@@ -22,5 +22,6 @@ namespace Diary_Sample.Services
         }
         public List<DiaryRow> Lists(int page) => _service.Lists(page, PageCount);
         public int Counts() => _service.Counts();
+        public bool Diary(int id, ref DiaryModel? diary) => _service.Diary(id, ref diary);
     }
 }

--- a/Diary-Sample/Services/IApiService.cs
+++ b/Diary-Sample/Services/IApiService.cs
@@ -12,5 +12,6 @@ namespace Diary_Sample.Services
     {
         public List<DiaryRow> Lists(int page);
         public int Counts();
+        public bool Diary(int id, ref DiaryModel? diary);
     }
 }

--- a/Diary-Sample/Services/ISharedService.cs
+++ b/Diary-Sample/Services/ISharedService.cs
@@ -12,5 +12,6 @@ namespace Diary_Sample.Services
     {
         public List<DiaryRow> Lists(int page, int count);
         public int Counts();
+        public bool Diary(int id, ref DiaryModel? diary);
     }
 }

--- a/Diary-Sample/Services/ReferService.cs
+++ b/Diary-Sample/Services/ReferService.cs
@@ -15,40 +15,31 @@ namespace Diary_Sample.Services
     public class ReferService : IReferService
     {
         private readonly IDiaryRepository _repository;
+        private readonly ISharedService _service;
 
-        public ReferService(IDiaryRepository repository)
+        public ReferService(IDiaryRepository repository, ISharedService service)
         {
             _repository = repository;
+            _service = service;
         }
 
         public ReferViewModel? GetDiary(int id)
         {
-            var diaryList = GetById(id);
-            if (diaryList.Count == 0)
+
+            DiaryModel? diary = null;
+            if (!_service.Diary(id, ref diary))
             {
                 return null;
             }
 
-            var diary = diaryList.First();
             ReferViewModel? viewModel = new ReferViewModel
             {
-                Id = diary.id.ToString(),
-                Title = diary.title,
-                Content = diary.content,
+                Id = diary.Id,
+                Title = diary.Title,
+                Content = diary.Content,
             };
 
             return viewModel;
-        }
-
-        private List<Diary> GetById(int id)
-        {
-            var diaryList = _repository.Read(id);
-            if (diaryList.Count != 1)
-            {
-                return new List<Diary>();
-            }
-
-            return diaryList;
         }
     }
 }

--- a/Diary-Sample/Services/SharedService.cs
+++ b/Diary-Sample/Services/SharedService.cs
@@ -27,5 +27,18 @@ namespace Diary_Sample.Services
                 .Select(diary => new DiaryRow(diary.id, diary.title, diary.post_date))
                 .ToList();
         public int Counts() => _repository.readCount();
+
+        public bool Diary(int id, ref DiaryModel? diary)
+        {
+            var diaryList = _repository.Read(id).Select(diary => new DiaryModel(diary.id, diary.title, diary.content)).ToList();
+            if (diaryList.Count != 1)
+            {
+                return false;
+            }
+
+            diary = diaryList[0];
+
+            return true;
+        }
     }
 }


### PR DESCRIPTION
id(連番)をキーに、日記のタイトルと本文を取得するAPIです。
実装してみたところ、以下2点、ちょっと迷っています。

RESTのメソッド名を"Diary"にしているのですが、
汎用的で紛らわしいかもしれないです。
getだと大雑把過ぎますし、
"oneDiary"みたいな単一の情報取得みたいなものにすると、
ちょっと冗長的過ぎる気がしています。

また、idをキーにして日記情報が取得できなかった場合、
空のBeanを返すようにしていますが、
例外を飛ばしたり、500番代エラーを返した方がいいかもしれないという気もしています。