### PR TITLE
Redisの環境変数を編集して設定するように修正

### DIFF
--- a/Diary-Sample/Startup.cs
+++ b/Diary-Sample/Startup.cs
@@ -75,7 +75,7 @@ namespace Diary_Sample
             var redis = Environment.GetEnvironmentVariable("REDIS_URL");
             services.AddSingleton<IConnectionMultiplexer>(ConnectionMultiplexer.Connect(
                 string.IsNullOrEmpty(redis) ? Configuration.GetConnectionString("SessionConnectionString")
-                : redis));
+                : redis.Split("@")[1] + ",password=" + redis.Split("@")[0].Split(":")[2]));
             services.AddScoped<RedisTicketStore>();
             services.AddDataProtection()
                     .SetApplicationName("Diary_Sample.Infra")


### PR DESCRIPTION
# 変更内容
Herokuで使用するRedisの環境変数を編集して設定するように修正しました。

現行の内容だとHeroku側で勝手に更新されてアプリが動かなくなるためです。
ここの内容に対応しています。
https://github.com/1-system-group/Diary-Sample/wiki/heroku-Tips#%E7%92%B0%E5%A2%83%E5%A4%89%E6%95%B0