### PR TITLE
認証トークン発行APIの追加

### DIFF
--- a/Diary-Sample/Controllers/ApiController.cs
+++ b/Diary-Sample/Controllers/ApiController.cs
@@ -3,10 +3,16 @@
 // Copyright (c) 1-system-group. All rights reserved.
 // </copyright>
 // -----------------------------------------------------------------------
+
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Diary_Sample.Infra;
 using Diary_Sample.Models;
 using Diary_Sample.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
@@ -19,17 +25,59 @@ namespace Diary_Sample.Controllers
     {
         private readonly ILogger<ApiController> _logger;
         private readonly IApiService _service;
-        public ApiController(ILogger<ApiController> logger, IApiService service)
+        private readonly UserManager<IdentityUser> _userManager;
+        private readonly IJwtHandler _jwtHandler;
+
+        public ApiController(ILogger<ApiController> logger, IApiService service,
+            UserManager<IdentityUser> userManager,
+            IJwtHandler jwtHandler)
         {
             _logger = logger;
             _service = service;
+            _userManager = userManager;
+            _jwtHandler = jwtHandler;
         }
 
+        [AllowAnonymous]
+        [HttpPost]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(BadRequestResult), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> Login(string email, string password, string deviceId)
+        {
+            IdentityUser user = await _userManager.FindByNameAsync(email).ConfigureAwait(false);
+            if (user == null)
+            {
+                return Unauthorized();
+            }
+
+            if (user.LockoutEnd != null)
+            {
+                // ロックされていたら認証エラー
+                return Unauthorized();
+            }
+
+            bool isPasswordOk = await _userManager.CheckPasswordAsync(user, password).ConfigureAwait(false);
+            if (isPasswordOk)
+            {
+                // 認証トークンを発行する
+                var roles = await _userManager.GetRolesAsync(user).ConfigureAwait(false);
+                var token = _jwtHandler.GenerateEncodedToken(user.UserName, deviceId, roles);
+                return Ok(token);
+            }
+
+            // 認証失敗回数をインクリメントし、最大試行回数行った場合はロックする
+            _userManager.AccessFailedAsync(user).ConfigureAwait(false);
+            return Unauthorized();
+        }
+
+        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("{page}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(BadRequestResult), StatusCodes.Status400BadRequest)]
-        public ActionResult<List<DiaryRow>> Lists(int page) => page > 0 ? (ActionResult)Ok(_service.Lists(page)) : BadRequest();
+        public ActionResult<List<DiaryRow>> Lists(int page) =>
+            page > 0 ? (ActionResult)Ok(_service.Lists(page)) : BadRequest();
 
+        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public ActionResult<int> Counts() => Ok(_service.Counts());

--- a/Diary-Sample/Controllers/IApiController.cs
+++ b/Diary-Sample/Controllers/IApiController.cs
@@ -4,7 +4,10 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Diary_Sample.Models;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -12,6 +15,24 @@ namespace Diary_Sample.Controllers
 {
     public interface IApiController
     {
+        /// <summary>
+        /// ログインする
+        /// </summary>
+        /// <remarks>
+        /// モバイルアプリからログインするためのAPI
+        /// </remarks>
+        /// <param name="email"></param>
+        /// <param name="password"></param>
+        /// <param name="deviceId"></param>
+        /// <returns>認証トークン</returns>
+        /// <response code="200">OK 認証トークン</response>
+        /// <response code="401">NG 認証失敗</response>
+        [AllowAnonymous]
+        [HttpPost]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(BadRequestResult), StatusCodes.Status400BadRequest)]
+        public Task<IActionResult> Login(string email, string password, string deviceId);
+
         /// <summary>
         /// 日記の情報一覧を取得する
         /// </summary>
@@ -35,6 +56,7 @@ namespace Diary_Sample.Controllers
         /// </remarks>
         /// <returns>日記の件数</returns>
         /// <response code="200">OK 日記の件数</response>
+        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public ActionResult<int> Counts();
@@ -50,6 +72,7 @@ namespace Diary_Sample.Controllers
         /// <returns>日記</returns>
         /// <response code="200">OK 日記</response>
         /// <response code="404">NG 日記</response>
+        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         [HttpGet("{id}")]
         [ProducesResponseType(typeof(DiaryModel), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(NotFoundResult), StatusCodes.Status404NotFound)]

--- a/Diary-Sample/Diary-Sample.csproj
+++ b/Diary-Sample/Diary-Sample.csproj
@@ -11,7 +11,7 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.29" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -24,7 +24,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
-    <PackageReference Include="MySql.Data.EntityFrameworkCore" Version="8.0.21" />
+    <PackageReference Include="MySql.Data.EntityFrameworkCore" Version="8.0.22" />
+    <PackageReference Include="MySql.Data" Version="8.0.29" />
     <PackageReference Include="NSwag.AspNetCore" Version="13.12.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
@@ -34,5 +35,7 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />
     <AdditionalFiles Include="stylecop.json" Link="stylecop.json" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.29" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.23.1" />
   </ItemGroup>
 </Project>

--- a/Diary-Sample/Infra/IJwtHandler.cs
+++ b/Diary-Sample/Infra/IJwtHandler.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Diary_Sample.Infra
+{
+    public interface IJwtHandler
+    {
+        public string GenerateEncodedToken(string userName, string deviceId, IList<string> roles);
+    }
+}

--- a/Diary-Sample/Infra/JwtConfigurableOptions.cs
+++ b/Diary-Sample/Infra/JwtConfigurableOptions.cs
@@ -1,0 +1,30 @@
+using System;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Diary_Sample.Infra
+{
+    public class JwtConfigurableOptions
+    {
+        public string JwtKey { get; set; }
+        public string JwtIssuer { get; set; }
+        public string JwtAudience { get; set; }
+        public int JwtExpireDays { get; set; }
+
+        public static JwtConfigurableOptions getJwtConfigurableOptions(JwtConfigurableOptions jwtConfigurableOptions)
+        {
+            var jwtExpireDays = Environment.GetEnvironmentVariable("JWT_CONFIGURABLE_OPTIONS_JWT_EXPIRE_DAYS");
+            return new JwtConfigurableOptions
+            {
+                JwtKey = Environment.GetEnvironmentVariable("JWT_CONFIGURABLE_OPTIONS_JWT_KEY") ??
+                         jwtConfigurableOptions.JwtKey,
+                JwtIssuer = Environment.GetEnvironmentVariable("JWT_CONFIGURABLE_OPTIONS_JWT_ISSUER") ??
+                            jwtConfigurableOptions.JwtIssuer,
+                JwtAudience = Environment.GetEnvironmentVariable("JWT_CONFIGURABLE_OPTIONS_JWT_AUDIENCE") ??
+                              jwtConfigurableOptions.JwtAudience,
+                JwtExpireDays = jwtExpireDays != null
+                    ? Convert.ToInt32(jwtExpireDays)
+                    : jwtConfigurableOptions.JwtExpireDays
+            };
+        }
+    }
+}

--- a/Diary-Sample/Infra/JwtHandler.cs
+++ b/Diary-Sample/Infra/JwtHandler.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Diary_Sample.Infra
+{
+    public class JwtHandler : IJwtHandler
+    {
+        private readonly JwtConfigurableOptions _jwtConfigurableOptions;
+
+        public JwtHandler(JwtConfigurableOptions jwtConfigurableOptions)
+        {
+            _jwtConfigurableOptions = jwtConfigurableOptions;
+        }
+
+        public string GenerateEncodedToken(string userName, string deviceId, IList<string> roles)
+        {
+            var jwtConfig = JwtConfigurableOptions.getJwtConfigurableOptions(_jwtConfigurableOptions);
+            List<Claim> claims = new List<Claim>
+            {
+                new Claim(JwtRegisteredClaimNames.Sub, userName),
+                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+                new Claim(JwtRegisteredClaimNames.Iat,
+                    DateTime.UtcNow.AddDays(jwtConfig.JwtExpireDays).Ticks.ToString(), ClaimValueTypes.Integer64),
+                new Claim(ClaimTypes.System, deviceId)
+            };
+
+            if (roles.Any())
+            {
+                claims.AddRange(roles.Select(role => new Claim(ClaimTypes.Role, role)));
+            }
+
+            // Create the JWT security token and encode it.
+            JwtSecurityToken jwt = new JwtSecurityToken(
+                issuer: jwtConfig.JwtIssuer,
+                audience: jwtConfig.JwtAudience,
+                claims: claims,
+                expires: DateTime.UtcNow.AddDays(jwtConfig.JwtExpireDays),
+                signingCredentials: new SigningCredentials(
+                    new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtConfig.JwtKey)),
+                    SecurityAlgorithms.HmacSha256)
+            );
+
+            return new JwtSecurityTokenHandler().WriteToken(jwt);
+        }
+    }
+}

--- a/Diary-Sample/appsettings.Development.json
+++ b/Diary-Sample/appsettings.Development.json
@@ -9,5 +9,11 @@
   "ConnectionStrings": {
     "DbConnectionString": "server=localhost;port=3306;database=DiarySample;userid=user;pwd=password;sslmode=Required;",
     "SessionConnectionString": "localhost"
+  },
+  "JwtConfigurableOptions": {
+    "JwtKey": "1-system-group-test-jwt_key",
+    "JwtIssuer": "1-system-group-issuer",
+    "JwtAudience": "1-system-group-audience",
+    "JwtExpireDays": 14
   }
 }

--- a/Diary-Sample/appsettings.Production.json
+++ b/Diary-Sample/appsettings.Production.json
@@ -9,5 +9,11 @@
   "ConnectionStrings": {
     "DbConnectionString": "server=db;port=3306;database=DiarySample;userid=user;pwd=password;sslmode=Required;",
     "SessionConnectionString": "redis"
+  },
+  "JwtConfigurableOptions": {
+    "JwtKey": "1-system-group-test-jwt_key",
+    "JwtIssuer": "1-system-group-issuer",
+    "JwtAudience": "1-system-group-audience",
+    "JwtExpireDays": 14
   }
 }


### PR DESCRIPTION
# 変更内容
モバイルアプリ（API）から認証を行うための認証APIを作成しました。

認証を行うと、APIにアクセスできる認証トークン（JWT）を発行するようになっています。
この認証トークンをAPIのリクエストヘッダに付与することでAPIが叩けるように制限しました。

```mermaid
sequenceDiagram
  mobile device ->>+Server: Login（userId, password, deviceId）
  Server-->>-mobile device: token

Note over mobile device,Server: ↓ set token in header

  mobile device ->>+Server: Lists（page）
  activate Server
  Server-->>-mobile device: response

   mobile device ->>+Server: Counts
  Server-->>-mobile device: response

  mobile device ->>+Server: Diary（id）
  Server-->>-mobile device: response
```

APIの確認はSwaggerで確認してください。
https://localhost:5001/swagger/index.html

認証には、ログインID（Eメールアドレス）、パスワード、デバイスID（端末で認証した際はその端末でしかトークンを使えないように、モバイル端末のUUIDを設定する予定）をパラメータ設定して実行します。
<img width="1453" alt="スクリーンショット 2022-10-10 20 18 34" src="https://user-images.githubusercontent.com/15532048/194855263-9e67ed2f-d1d1-40e3-99a2-a63082a12ee8.png">

認証は画面とAPIで別々にしています。
画面はセッションID、APIはトークンでそれぞれ行えることを制限しています。

また、Swaggerで認証トークンをヘッダに設定できるようにしました。
右上の「Authorize」で認証APIで取得したトークンを画像のように「bearer トークン（ダブルクォーテーションは除く）」と設定したうえで、既存のAPIが叩けるようになっています。

<img width="644" alt="スクリーンショット 2022-10-10 20 17 56" src="https://user-images.githubusercontent.com/15532048/194855226-d3036f69-f91c-4e8f-b561-418a0f44a866.png">

