### PR TITLE
本番環境のredis接続をTLS接続に対応

### DIFF
--- a/Diary-Sample/docker-compose.yml
+++ b/Diary-Sample/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   db:
-    image: mysql:8.0.39
+    image: mysql:8.0.35
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
     restart: always
     environment:
@@ -18,7 +18,7 @@ services:
     ports:
     - 3306:3306
   redis:
-      image: redis
+      image: redis:7.2.4
       ports:
         - "6379:6379"
       # volumes:


### PR DESCRIPTION
# 変更内容
HerokuのRedisがTLS接続のみになったため接続方法を修正しました。
https://devcenter.heroku.com/changelog-items/3064

ローカルのdocker-composeも本番環境に合わせてRedisとMySQLの同じバージョンを使用するように修正しました。