### PR TITLE
パスワードリセットAPIの追加

### DIFF
--- a/Diary-Sample/Controllers/IResetPasswordApiController.cs
+++ b/Diary-Sample/Controllers/IResetPasswordApiController.cs
@@ -1,0 +1,30 @@
+// -----------------------------------------------------------------------
+// <copyright file="IResetPasswordApiController.cs" company="1-system-group">
+// Copyright (c) 1-system-group. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+using Diary_Sample.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Diary_Sample.Controllers;
+
+public interface IResetPasswordApiController
+{
+    /// <summary>
+    /// パスワードをリセットする
+    /// </summary>
+    /// <remarks>
+    /// 受け取ったコードと新しいパスワードでパスワードをリセットする
+    /// </remarks>
+    /// <param name="model">パスワードリセットモデル</param>
+    /// <returns>処理結果</returns>
+    /// <response code="200">OK パスワードリセット完了</response>
+    /// <response code="400">NG 入力内容不正</response>
+    [AllowAnonymous]
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(BadRequestResult), StatusCodes.Status400BadRequest)]
+    public Task<ActionResult> ResetPassword([FromBody] ResetPasswordModel model);
+}

--- a/Diary-Sample/Controllers/ResetPasswordApiController.cs
+++ b/Diary-Sample/Controllers/ResetPasswordApiController.cs
@@ -1,0 +1,79 @@
+// -----------------------------------------------------------------------
+// <copyright file="ResetPasswordApiController.cs" company="1-system-group">
+// Copyright (c) 1-system-group. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Text;
+using Diary_Sample.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+
+namespace Diary_Sample.Controllers;
+
+[ApiController]
+[Route("api/v1/[action]")]
+[Produces("application/json")]
+public class ResetPasswordApiController : ControllerBase, IResetPasswordApiController
+{
+    private readonly ILogger<ResetPasswordApiController> _logger;
+    private readonly UserManager<IdentityUser> _userManager;
+    private readonly IConfiguration _configuration;
+    private readonly string _clientBaseUrl;
+    public ResetPasswordApiController(
+        ILogger<ResetPasswordApiController> logger,
+        UserManager<IdentityUser> userManager,
+        IConfiguration configuration)
+    {
+        _logger = logger;
+        _userManager = userManager;
+        _configuration = configuration;
+
+        _clientBaseUrl = Environment.GetEnvironmentVariable("CLIENT_BASE_URL") ?? _configuration["ClientBaseUrl"];
+        if (string.IsNullOrEmpty(_clientBaseUrl))
+        {
+            _logger.LogError("_clientBaseUrl is not configured");
+            throw new System.Exception();
+        }
+
+    }
+
+    /// <inheritdoc />
+    [AllowAnonymous]
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(BadRequestResult), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> ResetPassword([FromBody] ResetPasswordModel model)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(new { message = "入力内容が不正です。" });
+        }
+
+        var user = await _userManager.FindByEmailAsync(model.Email).ConfigureAwait(false);
+        if (user == null)
+        {
+            // ユーザーが存在しないことを明かさない
+            return Ok(new { message = "パスワードをリセットしました。" });
+        }
+
+        var code = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(model.Code));
+        var result = await _userManager.ResetPasswordAsync(user, code, model.Password).ConfigureAwait(false);
+        if (result.Succeeded)
+        {
+            return Ok(new { message = "パスワードをリセットしました。" });
+        }
+
+        foreach (var error in result.Errors)
+        {
+            _logger.LogWarning("パスワードリセットエラー: {Description}", error.Description);
+        }
+
+        return BadRequest(new { message = "パスワードのリセットに失敗しました。" });
+    }
+}

--- a/Diary-Sample/Controllers/ResetPasswordApiController.cs
+++ b/Diary-Sample/Controllers/ResetPasswordApiController.cs
@@ -24,7 +24,6 @@ public class ResetPasswordApiController : ControllerBase, IResetPasswordApiContr
     private readonly ILogger<ResetPasswordApiController> _logger;
     private readonly UserManager<IdentityUser> _userManager;
     private readonly IConfiguration _configuration;
-    private readonly string _clientBaseUrl;
     public ResetPasswordApiController(
         ILogger<ResetPasswordApiController> logger,
         UserManager<IdentityUser> userManager,
@@ -33,14 +32,6 @@ public class ResetPasswordApiController : ControllerBase, IResetPasswordApiContr
         _logger = logger;
         _userManager = userManager;
         _configuration = configuration;
-
-        _clientBaseUrl = Environment.GetEnvironmentVariable("CLIENT_BASE_URL") ?? _configuration["ClientBaseUrl"];
-        if (string.IsNullOrEmpty(_clientBaseUrl))
-        {
-            _logger.LogError("_clientBaseUrl is not configured");
-            throw new System.Exception();
-        }
-
     }
 
     /// <inheritdoc />

--- a/Diary-Sample/Controllers/ResetPasswordApiController.cs
+++ b/Diary-Sample/Controllers/ResetPasswordApiController.cs
@@ -23,7 +23,6 @@ public class ResetPasswordApiController : ControllerBase, IResetPasswordApiContr
 {
     private readonly ILogger<ResetPasswordApiController> _logger;
     private readonly UserManager<IdentityUser> _userManager;
-    private readonly IConfiguration _configuration;
     public ResetPasswordApiController(
         ILogger<ResetPasswordApiController> logger,
         UserManager<IdentityUser> userManager,
@@ -31,7 +30,6 @@ public class ResetPasswordApiController : ControllerBase, IResetPasswordApiContr
     {
         _logger = logger;
         _userManager = userManager;
-        _configuration = configuration;
     }
 
     /// <inheritdoc />

--- a/Diary-Sample/Models/ResetPasswordModel.cs
+++ b/Diary-Sample/Models/ResetPasswordModel.cs
@@ -1,0 +1,26 @@
+// -----------------------------------------------------------------------
+// <copyright file="ResetPasswordModel.cs" company="1-system-group">
+// Copyright (c) 1-system-group. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+using System.ComponentModel.DataAnnotations;
+
+namespace Diary_Sample.Models;
+
+public class ResetPasswordModel
+{
+    [Required(ErrorMessage = "Eメールは必須です。")]
+    [EmailAddress(ErrorMessage = "Eメールアドレスの形式で入力してください。")]
+    public string Email { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "パスワードは必須です。")]
+    [StringLength(100, ErrorMessage = "{0}は{2}〜{1}文字で入力してください。", MinimumLength = 6)]
+    public string Password { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "確認用パスワードは必須です。")]
+    [Compare("Password", ErrorMessage = "パスワードと確認用パスワードが不一致です。")]
+    public string ConfirmPassword { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "コードは必須です。")]
+    public string Code { get; set; } = string.Empty;
+}


### PR DESCRIPTION
# 変更内容
vue.jsの「パスワードリセット画面→パスワードリセット完了画面」の遷移で呼び出されるAPIを追加しました。

処理内容は元々.NETのパスワードリセット処理で行っていたものと同じです。

パスワードリセット申請メール送信のAPIクラス（ForgotPasswordApiController.cs）とは別クラスにしました。

本APIが呼び出される画面のPRは以下です。
https://github.com/1-system-group/Diary-Sample-Front-End/pull/10
