### PR TITLE
[hotfix]日記取得APIの認証が効いていないため修正

### DIFF
--- a/Diary-Sample/Controllers/ApiController.cs
+++ b/Diary-Sample/Controllers/ApiController.cs
@@ -89,6 +89,7 @@ public class ApiController : ControllerBase, IApiController
     public ActionResult<int> Counts() => Ok(_service.Counts());
 
     /// <inheritdoc />
+    [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
     [HttpGet("{id}")]
     [ProducesResponseType(typeof(DiaryModel), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(NotFoundResult), StatusCodes.Status404NotFound)]

--- a/Diary-Sample/Controllers/IApiController.cs
+++ b/Diary-Sample/Controllers/IApiController.cs
@@ -39,6 +39,7 @@ public interface IApiController
     /// <returns>日記の情報リスト</returns>
     /// <response code="200">OK 日記の情報リスト</response>
     /// <response code="400">NG 不正なページ指定</response>
+    [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
     [HttpGet("{page}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(BadRequestResult), StatusCodes.Status400BadRequest)]


### PR DESCRIPTION
# 変更内容
日記取得APIの認証が効いていないので効くように修正しました。

また、日記の情報一覧APIのAPIドキュメントに認証の内容が出力されていかったので追加しました。